### PR TITLE
NCD-584: Add a better view of the toggle and pmic config

### DIFF
--- a/src/features/ConfigDataPreview/ConfigDataPreview.tsx
+++ b/src/features/ConfigDataPreview/ConfigDataPreview.tsx
@@ -8,18 +8,26 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { logger } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
-import { getConfigArray } from '../Configuration/boardControllerConfigSlice';
+import {
+    getConfigArray,
+    getConfigData,
+    getPmicConfigData,
+} from '../Configuration/boardControllerConfigSlice';
 import {
     getBoardControllerFirmwareVersion,
     getBoardRevisionSemver,
 } from '../Device/deviceSlice';
+
+import './configdatapreview.scss';
 
 const ConfigDataPreview: React.FC<{
     enabled: boolean;
 }> = ({ enabled = true }) => {
     logger.debug('Rendering ConfigDataPreview');
 
-    const configData = useSelector(getConfigArray);
+    const configArray = useSelector(getConfigArray);
+    const configData = useSelector(getConfigData);
+    const pmicData = useSelector(getPmicConfigData);
     const boardRevision = useSelector(getBoardRevisionSemver);
     const boardControllerFirmwareVersion = useSelector(
         getBoardControllerFirmwareVersion
@@ -27,25 +35,61 @@ const ConfigDataPreview: React.FC<{
 
     if (enabled) {
         return (
-            <div>
-                <div>{JSON.stringify(configData)}</div>
-
+            <div className="sidepanel-group">
                 {boardRevision ? (
                     <div>
+                        <h3 className="heading">Board Controller</h3>
                         <p>
-                            Board Revision:
-                            {boardRevision}
+                            Board Hardware Revision:
+                            <br /> {boardRevision}
                         </p>
                         <p>
                             BoardController FW version:
-                            {boardControllerFirmwareVersion}
+                            <br /> {boardControllerFirmwareVersion}
                         </p>
                     </div>
                 ) : null}
+
+                {configData && configData.size > 0 && (
+                    <>
+                        <h2 className="heading">Toggles</h2>
+                        <div className="config-block">
+                            <table>{configList(configData)}</table>
+                        </div>
+                    </>
+                )}
+                {pmicData && pmicData.size > 0 && (
+                    <>
+                        <h2 className="heading">PMIC configuration</h2>
+                        <div className="config-block">{pmicList(pmicData)}</div>
+                    </>
+                )}
             </div>
         );
     }
     return null;
 };
+
+function configList(configData: Map<number, boolean>) {
+    const pins = Array.from(configData.keys()).sort((a, b) => a - b);
+    return pins.map(pin => (
+        <tr key={`pin-${pin}`}>
+            <td className="config-pin">{pin}</td>
+            <td className="config-value">
+                {configData.get(pin) ? 'true' : 'false'}
+            </td>
+        </tr>
+    ));
+}
+
+function pmicList(pmicData: Map<number, number>) {
+    const ports = Array.from(pmicData.keys()).sort();
+    return ports.map(port => (
+        <div key={`port-${port}`}>
+            <span className="config-pin">{port}</span>
+            <span className="config-value">{pmicData.get(port)}</span>
+        </div>
+    ));
+}
 
 export default ConfigDataPreview;

--- a/src/features/ConfigDataPreview/configdatapreview.scss
+++ b/src/features/ConfigDataPreview/configdatapreview.scss
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+// This file is imported by Hello.jsx, and may contain styles for that component.
+
+@import '~@nordicsemiconductor/pc-nrfconnect-shared/styles';
+
+.config-block {
+    font-size: 12pt;
+    margin: 10px;
+    padding: 10px;
+    //border: 1px black solid;
+    max-width: 150px;
+}
+
+.config-pin {
+    padding: 0 0 10px 10px;
+    margin-right: 10px;
+    font-weight: bold;
+}
+
+.config-value {
+    padding: 0 0 10px 10px;
+    font-style: italic;
+}

--- a/src/features/Configuration/boardControllerConfigSlice.ts
+++ b/src/features/Configuration/boardControllerConfigSlice.ts
@@ -16,7 +16,8 @@ interface ConfigState {
 // nRF54H20 default config
 const initialState: ConfigState = {
     boardControllerConfigData: new Map([]),
-    pmicConfigData: new Map([[1, 1800]]),
+    // This might be needed pmicConfigData: new Map([[1, 1800]]),
+    pmicConfigData: new Map([]),
 };
 
 const boardControllerConfigSlice = createSlice({


### PR DESCRIPTION
Fixed some tings in the side panel:
 * View config pins/toggles as a list
 * View PMIC values as a list
 * Better formatting of versions
 * Remove JSON strings