### PR TITLE
Version bump to release v0.1.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,12 +5,13 @@
 EXPERIMENTAL RELEASE
 
 ### Added
--    Feedback form.
--    List of supported Development Kits.
+
+-   Feedback form.
+-   List of supported Development Kits.
 
 ### Changed
 
--    Minimum version of nRF Connect for Desktop
+-   Minimum version of nRF Connect for Desktop
 
 ## 0.1.0 - 2024-01-15
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.1 - 2024-01-18
+
+EXPERIMENTAL RELEASE
+
+-   Added a feedback form
+-   Added list of supported Development Kits
+-   Updated dependencies to avoid starting and crashing on old nRF Connect
+    Launcher
+
 ## 0.1.0 - 2024-01-15
 
 EXPERIMENTAL RELEASE

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,10 +4,13 @@
 
 EXPERIMENTAL RELEASE
 
--   Added a feedback form
--   Added list of supported Development Kits
--   Updated dependencies to avoid starting and crashing on old nRF Connect
-    Launcher
+### Added
+-    Feedback form.
+-    List of supported Development Kits.
+
+### Changed
+
+-    Minimum version of nRF Connect for Desktop
 
 ## 0.1.0 - 2024-01-15
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",


### PR DESCRIPTION
Changes in this release:

* Added a feedback form
* Added list of supported Development Kits
* Updated dependencies to avoid starting and crashing on old nRF Connect Launcher