### PR TITLE
Reference eslint config from @nordicsemi package to work in workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "@types/react-test-renderer": "18.0.0"
     },
     "eslintConfig": {
-        "extends": "./node_modules/@nordicsemiconductor/pc-nrfconnect-shared/config/eslintrc"
+        "extends": "@nordicsemiconductor/pc-nrfconnect-shared/config/eslintrc"
     },
     "prettier": "@nordicsemiconductor/pc-nrfconnect-shared/config/prettier.config.js"
 }


### PR DESCRIPTION
This fixes the linter errors when used from a workspace.