### PR TITLE
NCD-660: Disable write button on click, enable on write finished

### DIFF
--- a/src/SidePanel.tsx
+++ b/src/SidePanel.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
     Button,
@@ -21,6 +21,8 @@ import { getConfigArray } from './features/Configuration/boardControllerConfigSl
 export default () => {
     logger.debug('Rendering SidePanel');
 
+    const [isWriting, setWriting] = useState(false);
+
     const device = useSelector(selectedDevice);
     const configData = useSelector(getConfigArray);
 
@@ -28,12 +30,13 @@ export default () => {
         <SidePanel className="side-panel">
             <CollapsibleGroup defaultCollapsed={false} heading="Actions">
                 <Button
-                    disabled={!device}
+                    disabled={!device || isWriting}
                     variant="primary"
                     className="tw-w-full"
                     onClick={async event => {
                         const button = event.currentTarget;
-                        button.classList.add('disabled');
+                        // Set isWriting flag for user ui feedback
+                        setWriting(true);
                         if (!device) {
                             return;
                         }
@@ -42,7 +45,8 @@ export default () => {
                             configData
                         );
                         logger.info('Configuration written');
-                        button.classList.remove('disabled');
+                        // Clear isWriting flag for user ui feedback
+                        setWriting(false);
                     }}
                 >
                     Write config

--- a/src/SidePanel.tsx
+++ b/src/SidePanel.tsx
@@ -31,12 +31,18 @@ export default () => {
                     disabled={!device}
                     variant="primary"
                     className="tw-w-full"
-                    onClick={() => {
+                    onClick={async event => {
+                        const button = event.currentTarget;
+                        button.classList.add('disabled');
                         if (!device) {
                             return;
                         }
-                        NrfutilDeviceLib.boardController(device, configData);
+                        await NrfutilDeviceLib.boardController(
+                            device,
+                            configData
+                        );
                         logger.info('Configuration written');
+                        button.classList.remove('disabled');
                     }}
                 >
                     Write config


### PR DESCRIPTION
This feature will tell users that we are writing the configuration to the DK, by greying the "Write config"-button on click. After the write is finished, we "re-enable" the button, indicating that the write is finished. (In addition to logging "Configuration written")