### PR TITLE
Bump version to release v0.1.3. Updated Changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.3 - 2024-01-31
+
+EXPERIMENTAL RELEASE
+
+### Added
+
+-   Preliminary support for nRF54L15-DK (rev. 0.2.x and 0.3.0)
+
 ## 0.1.2 - 2024-01-30
 
 EXPERIMENTAL RELEASE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",


### PR DESCRIPTION
Changelog:

## 0.1.3 - 2024-01-31

EXPERIMENTAL RELEASE

### Added

-   Preliminary support for nRF54L15-DK (rev. 0.2.x and 0.3.0)
