### PR TITLE
NCD-343: Read configuration, merge with defaults, show in GUI

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.4 - 2024-02-08
+
+EXPERIMENTAL RELEASE
+
+### Added
+
+-   Support reading configuration from board controller
+
 ## 0.1.3 - 2024-01-31
 
 EXPERIMENTAL RELEASE

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.1.1",
+    "version": "0.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pc-nrfconnect-board-configurator",
-            "version": "0.1.1",
+            "version": "0.1.3",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
-                "@nordicsemiconductor/pc-nrfconnect-shared": "152.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "156.0.0",
                 "@types/react-test-renderer": "18.0.0"
             },
             "engines": {
@@ -2848,9 +2848,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "152.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-152.0.0.tgz",
-            "integrity": "sha512-H60TjXqUfVDRiKol2Ackw8A1xE2jfRihkhsnvAPYnElsSKxEs3SIBWnFz3csJLMfmCajO7mRsIAxI1gVACVwmQ==",
+            "version": "156.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-156.0.0.tgz",
+            "integrity": "sha512-a6K2hM1J/O1GlKTxBY9jYXAWiT+ReFNeO1g76HybyAuKmX7cfE2wGKMWt+X5ar4H20/Ylp7cAQ708xUWXX87Dg==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "prepare": "husky install"
     },
     "devDependencies": {
-        "@nordicsemiconductor/pc-nrfconnect-shared": "152.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "156.0.0",
         "@types/react-test-renderer": "18.0.0"
     },
     "eslintConfig": {

--- a/src/SidePanel.tsx
+++ b/src/SidePanel.tsx
@@ -51,29 +51,6 @@ export default () => {
                 >
                     Write config
                 </Button>
-                <Button
-                    disabled={!device}
-                    variant="secondary"
-                    className="w-100"
-                    onClick={async () => {
-                        console.dir(device);
-                        if (!device) {
-                            return;
-                        }
-                        const boardControllerConfig =
-                            await NrfutilDeviceLib.getBoardControllerConfig(
-                                device
-                            );
-                        console.dir(boardControllerConfig);
-                        logger.info(
-                            `Got boardControllerConfig: ${JSON.stringify(
-                                boardControllerConfig
-                            )}`
-                        );
-                    }}
-                >
-                    Get BoardController config
-                </Button>
             </CollapsibleGroup>
             <CollapsibleGroup defaultCollapsed heading="Configuration data">
                 <ConfigDataPreview enabled />

--- a/src/SidePanel.tsx
+++ b/src/SidePanel.tsx
@@ -33,8 +33,7 @@ export default () => {
                     disabled={!device || isWriting}
                     variant="primary"
                     className="tw-w-full"
-                    onClick={async event => {
-                        const button = event.currentTarget;
+                    onClick={async () => {
                         // Set isWriting flag for user ui feedback
                         setWriting(true);
                         if (!device) {

--- a/src/SidePanel.tsx
+++ b/src/SidePanel.tsx
@@ -51,6 +51,29 @@ export default () => {
                 >
                     Write config
                 </Button>
+                <Button
+                    disabled={!device}
+                    variant="secondary"
+                    className="w-100"
+                    onClick={async () => {
+                        console.dir(device);
+                        if (!device) {
+                            return;
+                        }
+                        const boardControllerConfig =
+                            await NrfutilDeviceLib.getBoardControllerConfig(
+                                device
+                            );
+                        console.dir(boardControllerConfig);
+                        logger.info(
+                            `Got boardControllerConfig: ${JSON.stringify(
+                                boardControllerConfig
+                            )}`
+                        );
+                    }}
+                >
+                    Get BoardController config
+                </Button>
             </CollapsibleGroup>
             <CollapsibleGroup defaultCollapsed heading="Configuration data">
                 <ConfigDataPreview enabled />

--- a/src/app/DeviceSelector.tsx
+++ b/src/app/DeviceSelector.tsx
@@ -80,9 +80,6 @@ const getBoardControllerVersion = async (
     dispatch: AppDispatch,
     device: Device
 ) => {
-    if (!device) {
-        return;
-    }
     const bcVersion = await NrfutilDeviceLib.getBoardControllerVersion(device);
     console.log('Got device state %o', bcVersion);
     dispatch(

--- a/src/app/DeviceSelector.tsx
+++ b/src/app/DeviceSelector.tsx
@@ -19,8 +19,11 @@ import {
 
 import {
     clearConfig,
+    clearHardwareConfig,
     clearPmicConfig,
+    setHardwareConfig,
 } from '../features/Configuration/boardControllerConfigSlice';
+import { wrapHardwareConfig } from '../features/Configuration/hardwareConfiguration';
 import {
     clearBoardControllerFirmwareVersion,
     clearBoardRevision,
@@ -59,9 +62,10 @@ const deviceListing: DeviceTraits = {
  * Note that the callbacks releaseCurrentDevice and onDeviceIsReady
  * are only invoked, if a deviceSetup is defined.
  */
-const onDeviceSelected = (dispatch: AppDispatch) => (device: Device) => {
+const onDeviceSelected = (dispatch: AppDispatch) => async (device: Device) => {
     logger.info(`Selected device with s/n ${device.serialNumber}`);
-    getBoardControllerVersion(dispatch, device); // FIXME: Remove this when onDeviceIsReady() is called
+    await getBoardControllerVersion(dispatch, device); // FIXME: Remove this when onDeviceIsReady() is called
+    await getCurrentBoardControllerConfig(dispatch, device); // FIXME: Remove this when onDeviceIsReady() is called
 };
 
 const onDeviceIsReady = (dispatch: AppDispatch) => (device: Device) => {
@@ -91,12 +95,28 @@ const getBoardControllerVersion = async (
     dispatch(setBoardControllerFirmwareVersion(bcVersion.bc_fw_ver));
 };
 
+const getCurrentBoardControllerConfig = async (
+    dispatch: AppDispatch,
+    device: Device
+) => {
+    if (!device) {
+        return;
+    }
+    const currentConfig = await NrfutilDeviceLib.getBoardControllerConfig(
+        device
+    );
+    console.log('Read current config %o', currentConfig);
+    const wrappedConfig = wrapHardwareConfig(currentConfig);
+    dispatch(setHardwareConfig({ hardwareConfig: wrappedConfig }));
+};
+
 const onDeviceDeselected = (dispatch: AppDispatch) => () => {
     logger.info('Deselected device');
     dispatch(clearBoardRevision());
     dispatch(clearBoardControllerFirmwareVersion());
     dispatch(clearConfig());
     dispatch(clearPmicConfig());
+    dispatch(clearHardwareConfig());
 };
 
 export default () => {

--- a/src/features/ConfigDataPreview/ConfigDataPreview.tsx
+++ b/src/features/ConfigDataPreview/ConfigDataPreview.tsx
@@ -6,11 +6,12 @@
 
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { logger } from '@nordicsemiconductor/pc-nrfconnect-shared';
+import { HashType, logger } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import {
     getConfigArray,
     getConfigData,
+    getHardwareConfig,
     getPmicConfigData,
 } from '../Configuration/boardControllerConfigSlice';
 import {
@@ -27,7 +28,6 @@ interface ConfigDataPreviewProps {
 const ConfigDataPreview = ({ enabled = true }: ConfigDataPreviewProps) => {
     logger.debug('Rendering ConfigDataPreview');
 
-    const configArray = useSelector(getConfigArray);
     const configData = useSelector(getConfigData);
     const pmicData = useSelector(getPmicConfigData);
     const boardRevision = useSelector(getBoardRevisionSemver);
@@ -54,7 +54,9 @@ const ConfigDataPreview = ({ enabled = true }: ConfigDataPreviewProps) => {
 
                 {configData && configData.size > 0 && (
                     <>
-                        <h2 className="heading">Toggles</h2>
+                        <h2 className="heading">
+                            Board Controller pin configuration
+                        </h2>
                         <div className="config-block">
                             <table>{configList(configData)}</table>
                         </div>

--- a/src/features/ConfigDataPreview/ConfigDataPreview.tsx
+++ b/src/features/ConfigDataPreview/ConfigDataPreview.tsx
@@ -6,12 +6,10 @@
 
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { HashType, logger } from '@nordicsemiconductor/pc-nrfconnect-shared';
+import { logger } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import {
-    getConfigArray,
     getConfigData,
-    getHardwareConfig,
     getPmicConfigData,
 } from '../Configuration/boardControllerConfigSlice';
 import {

--- a/src/features/ConfigSlideSelector/ConfigSlideSelector.tsx
+++ b/src/features/ConfigSlideSelector/ConfigSlideSelector.tsx
@@ -6,11 +6,7 @@
 
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-    Card,
-    logger,
-    StateSelector,
-} from '@nordicsemiconductor/pc-nrfconnect-shared';
+import { Card, StateSelector } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import {
     getConfigValue,

--- a/src/features/ConfigSwitch/ConfigSwitch.tsx
+++ b/src/features/ConfigSwitch/ConfigSwitch.tsx
@@ -6,11 +6,7 @@
 
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-    Card,
-    logger,
-    Toggle,
-} from '@nordicsemiconductor/pc-nrfconnect-shared';
+import { Card, Toggle } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import {
     getConfigValue,

--- a/src/features/Configuration/boardControllerConfigSlice.ts
+++ b/src/features/Configuration/boardControllerConfigSlice.ts
@@ -7,10 +7,12 @@
 import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import type { RootState } from '../../app/appReducer';
+import { BoardConfiguration } from './hardwareConfiguration';
 
 interface ConfigState {
     boardControllerConfigData: Map<number, boolean>;
     pmicConfigData: Map<number, number>;
+    hardwareConfig: BoardConfiguration;
 }
 
 // nRF54H20 default config
@@ -18,6 +20,7 @@ const initialState: ConfigState = {
     boardControllerConfigData: new Map([]),
     // This might be needed pmicConfigData: new Map([[1, 1800]]),
     pmicConfigData: new Map([]),
+    hardwareConfig: {},
 };
 
 const boardControllerConfigSlice = createSlice({
@@ -65,6 +68,19 @@ const boardControllerConfigSlice = createSlice({
         clearPmicConfig(state) {
             state.pmicConfigData.clear();
         },
+
+        setHardwareConfig(
+            state,
+            {
+                payload: { hardwareConfig },
+            }: PayloadAction<{ hardwareConfig: BoardConfiguration }>
+        ) {
+            state.hardwareConfig = hardwareConfig;
+        },
+
+        clearHardwareConfig(state) {
+            state.hardwareConfig = {};
+        },
     },
 });
 
@@ -85,6 +101,9 @@ export const getConfigData = (state: RootState) =>
 
 export const getPmicConfigData = (state: RootState) =>
     state.app.boardControllerConfig.pmicConfigData;
+
+export const getHardwareConfig = (state: RootState) =>
+    state.app.boardControllerConfig.hardwareConfig;
 
 export const getConfigArray = createSelector(
     [getConfigData, getPmicConfigData],
@@ -114,6 +133,8 @@ export const {
     setPmicConfig,
     setPmicConfigValue,
     clearPmicConfig,
+    setHardwareConfig,
+    clearHardwareConfig,
 } = boardControllerConfigSlice.actions;
 
 export default boardControllerConfigSlice;

--- a/src/features/Configuration/hardwareConfiguration.ts
+++ b/src/features/Configuration/hardwareConfiguration.ts
@@ -22,7 +22,7 @@ export function wrapHardwareConfig(
         return { pins, pmicPorts };
     }
     console.log('No current config to apply');
-    return {};
+    return { pins: new Map<number, boolean>() };
 }
 
 export function wrapPinConfig(hardwarePinConfig: unknown[]) {

--- a/src/features/Configuration/hardwareConfiguration.ts
+++ b/src/features/Configuration/hardwareConfiguration.ts
@@ -1,0 +1,51 @@
+export interface BoardConfiguration {
+    pins?: Map<number, boolean>;
+    pmicPorts?: Map<number, number>;
+}
+
+export function wrapHardwareConfig(
+    hardwareConfig: unknown[][]
+): BoardConfiguration {
+    if (hardwareConfig && hardwareConfig.length !== 0) {
+        const pins = wrapPinConfig(hardwareConfig[0]);
+
+        const pmicPorts = wrapPmicConfig(
+            hardwareConfig.length > 1 ? hardwareConfig[1] : undefined
+        );
+
+        return { pins, pmicPorts };
+    }
+    console.log('No current config to apply');
+    return {};
+}
+
+export function wrapPinConfig(hardwarePinConfig: unknown[]) {
+    const pins = new Map<number, boolean>();
+
+    // Zip the current config pins array - NB! step of 2
+    for (let i = 0; i < hardwarePinConfig.length; i += 2) {
+        pins.set(
+            Number(hardwarePinConfig[i]),
+            Boolean(hardwarePinConfig[i + 1])
+        );
+    }
+
+    return pins;
+}
+
+export function wrapPmicConfig(hardwarePmicConfig: unknown[] | undefined) {
+    const ports = new Map<number, number>();
+    if (hardwarePmicConfig === undefined) {
+        return ports;
+    }
+
+    // Zip the current PMIC config port array - NB! step of 2
+    for (let i = 0; i < hardwarePmicConfig.length; i += 2) {
+        ports.set(
+            Number(hardwarePmicConfig[i]),
+            Number(hardwarePmicConfig[i + 1])
+        );
+    }
+
+    return ports;
+}

--- a/src/features/Configuration/hardwareConfiguration.ts
+++ b/src/features/Configuration/hardwareConfiguration.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
 export interface BoardConfiguration {
     pins?: Map<number, boolean>;
     pmicPorts?: Map<number, number>;


### PR DESCRIPTION
* Read configuration from firmware, using nrfutil-device commands in shared.
* Wrap configuration and merge with boards defaults from the board definition file
* Set current hardware configuration in state to update GUI
