### PR TITLE
Update types on default pins in board definition files

### DIFF
--- a/src/common/boards/BoardControllerConfigDefinition.ts
+++ b/src/common/boards/BoardControllerConfigDefinition.ts
@@ -47,8 +47,8 @@ type BoardDefinition = {
     boardName?: string;
 };
 
-type ConfigPin = [number, boolean];
-type PmicConfigPort = [number, number];
+type ConfigPin = { pin: number; state: boolean };
+type PmicConfigPort = { port: number; voltage: number };
 
 type PinType =
     | SwitchConfigDefinition

--- a/src/common/boards/nrf_PCA10153_0.10.0_9161.json
+++ b/src/common/boards/nrf_PCA10153_0.10.0_9161.json
@@ -107,18 +107,56 @@
     ],
     "defaults": {
         "pins": [
-            [42, false],
-            [20, false],
-            [22, false],
-            [23, false],
-            [6, false],
-            [7, false],
-            [8, false],
-            [14, false],
-            [18, false],
-            [45, false],
-            [47, true]
+            {
+                "pin": 42,
+                "state": false
+            },
+            {
+                "pin": 20,
+                "state": false
+            },
+            {
+                "pin": 22,
+                "state": false
+            },
+            {
+                "pin": 23,
+                "state": false
+            },
+            {
+                "pin": 6,
+                "state": false
+            },
+            {
+                "pin": 7,
+                "state": false
+            },
+            {
+                "pin": 8,
+                "state": false
+            },
+            {
+                "pin": 14,
+                "state": false
+            },
+            {
+                "pin": 18,
+                "state": false
+            },
+            {
+                "pin": 45,
+                "state": false
+            },
+            {
+                "pin": 47,
+                "state": true
+            }
         ],
-        "pmicPorts": [[2, 1800]]
+        "pmicPorts": [
+            {
+                "port": 2,
+                "voltage": 1800
+            }
+        ]
     }
 }

--- a/src/common/boards/nrf_PCA10153_0.9.1_9161.json
+++ b/src/common/boards/nrf_PCA10153_0.9.1_9161.json
@@ -102,17 +102,50 @@
     ],
     "defaults": {
         "pins": [
-            [42, false],
-            [20, false],
-            [22, false],
-            [23, false],
-            [6, false],
-            [7, false],
-            [8, false],
-            [14, true],
-            [18, true],
-            [45, false],
-            [47, false]
+            {
+                "pin": 42,
+                "state": false
+            },
+            {
+                "pin": 20,
+                "state": false
+            },
+            {
+                "pin": 22,
+                "state": false
+            },
+            {
+                "pin": 23,
+                "state": false
+            },
+            {
+                "pin": 6,
+                "state": false
+            },
+            {
+                "pin": 7,
+                "state": false
+            },
+            {
+                "pin": 8,
+                "state": false
+            },
+            {
+                "pin": 14,
+                "state": true
+            },
+            {
+                "pin": 18,
+                "state": true
+            },
+            {
+                "pin": 45,
+                "state": false
+            },
+            {
+                "pin": 47,
+                "state": false
+            }
         ]
     }
 }

--- a/src/common/boards/nrf_PCA10156_0.2.0.json
+++ b/src/common/boards/nrf_PCA10156_0.2.0.json
@@ -48,12 +48,32 @@
     ],
     "defaults": {
         "pins": [
-            [42, true],
-            [20, false],
-            [22, true],
-            [23, false],
-            [45, true]
+            {
+                "pin": 42,
+                "state": true
+            },
+            {
+                "pin": 20,
+                "state": false
+            },
+            {
+                "pin": 22,
+                "state": true
+            },
+            {
+                "pin": 23,
+                "state": false
+            },
+            {
+                "pin": 45,
+                "state": true
+            }
         ],
-        "pmicPorts": [[1, 1800]]
+        "pmicPorts": [
+            {
+                "port": 1,
+                "voltage": 1800
+            }
+        ]
     }
 }

--- a/src/common/boards/nrf_PCA10156_0.3.0.json
+++ b/src/common/boards/nrf_PCA10156_0.3.0.json
@@ -57,13 +57,36 @@
     ],
     "defaults": {
         "pins": [
-            [42, true],
-            [20, false],
-            [22, true],
-            [23, false],
-            [45, true],
-            [6, true]
+            {
+                "pin": 42,
+                "state": true
+            },
+            {
+                "pin": 20,
+                "state": false
+            },
+            {
+                "pin": 22,
+                "state": true
+            },
+            {
+                "pin": 23,
+                "state": false
+            },
+            {
+                "pin": 45,
+                "state": true
+            },
+            {
+                "pin": 6,
+                "state": true
+            }
         ],
-        "pmicPorts": [[1, 1800]]
+        "pmicPorts": [
+            {
+                "port": 1,
+                "voltage": 1800
+            }
+        ]
     }
 }

--- a/src/features/Configuration/Configuration.tsx
+++ b/src/features/Configuration/Configuration.tsx
@@ -244,10 +244,13 @@ function setInitialConfig(
 
     // Create defaults map
     const defaultConfig: Map<number, boolean> = new Map(
-        boardJson.defaults?.pins || []
+        (boardJson.defaults?.pins || []).map(({ pin, state }) => [pin, state])
     );
     const defaultPmicConfig: Map<number, number> = new Map(
-        boardJson.defaults?.pmicPorts || []
+        (boardJson.defaults?.pmicPorts || []).map(({ port, voltage }) => [
+            port,
+            voltage,
+        ])
     );
 
     // Merge with currently read hardware config


### PR DESCRIPTION
* Use objects instead of tuples for default pins and ports to avoid typing issues