### PR TITLE
NCD-747: Refactor definition loading, add "Reset to default" button

### DIFF
--- a/src/SidePanel.tsx
+++ b/src/SidePanel.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
     Button,
     CollapsibleGroup,
@@ -16,15 +16,23 @@ import {
 import { NrfutilDeviceLib } from '@nordicsemiconductor/pc-nrfconnect-shared/nrfutil/device';
 
 import ConfigDataPreview from './features/ConfigDataPreview/ConfigDataPreview';
-import { getConfigArray } from './features/Configuration/boardControllerConfigSlice';
+import {
+    getConfigArray,
+    getDefaultConfig,
+    setConfig,
+    setPmicConfig,
+} from './features/Configuration/boardControllerConfigSlice';
 
 export default () => {
     logger.debug('Rendering SidePanel');
 
     const [isWriting, setWriting] = useState(false);
 
+    const dispatch = useDispatch();
+
     const device = useSelector(selectedDevice);
     const configData = useSelector(getConfigArray);
+    const defaultConfig = useSelector(getDefaultConfig);
 
     return (
         <SidePanel className="side-panel">
@@ -49,6 +57,31 @@ export default () => {
                     }}
                 >
                     Write config
+                </Button>
+                <Button
+                    disabled={!device || isWriting || !defaultConfig}
+                    variant="secondary"
+                    className="tw-w-full"
+                    onClick={() => {
+                        logger.info('Reset to default');
+                        const { pins, pmicPorts } = defaultConfig;
+                        if (pins) {
+                            dispatch(
+                                setConfig({
+                                    boardControllerConfig: pins,
+                                })
+                            );
+                        }
+                        if (pmicPorts) {
+                            dispatch(
+                                setPmicConfig({
+                                    pmicConfig: pmicPorts,
+                                })
+                            );
+                        }
+                    }}
+                >
+                    Load default config
                 </Button>
             </CollapsibleGroup>
             <CollapsibleGroup defaultCollapsed heading="Configuration data">

--- a/src/app/DeviceSelector.tsx
+++ b/src/app/DeviceSelector.tsx
@@ -19,6 +19,7 @@ import {
 
 import {
     clearConfig,
+    clearDefaultConfig,
     clearHardwareConfig,
     clearPmicConfig,
     setHardwareConfig,
@@ -114,6 +115,7 @@ const onDeviceDeselected = (dispatch: AppDispatch) => () => {
     dispatch(clearConfig());
     dispatch(clearPmicConfig());
     dispatch(clearHardwareConfig());
+    dispatch(clearDefaultConfig());
 };
 
 export default () => {

--- a/src/features/Configuration/boardControllerConfigSlice.ts
+++ b/src/features/Configuration/boardControllerConfigSlice.ts
@@ -13,6 +13,7 @@ interface ConfigState {
     boardControllerConfigData: Map<number, boolean>;
     pmicConfigData: Map<number, number>;
     hardwareConfig: BoardConfiguration;
+    defaultConfig: BoardConfiguration;
 }
 
 // nRF54H20 default config
@@ -21,6 +22,7 @@ const initialState: ConfigState = {
     // This might be needed pmicConfigData: new Map([[1, 1800]]),
     pmicConfigData: new Map([]),
     hardwareConfig: {},
+    defaultConfig: {},
 };
 
 const boardControllerConfigSlice = createSlice({
@@ -81,6 +83,18 @@ const boardControllerConfigSlice = createSlice({
         clearHardwareConfig(state) {
             state.hardwareConfig = {};
         },
+        setDefaultConfig(
+            state,
+            {
+                payload: { defaultConfig },
+            }: PayloadAction<{ defaultConfig: BoardConfiguration }>
+        ) {
+            state.defaultConfig = defaultConfig;
+        },
+
+        clearDefaultConfig(state) {
+            state.defaultConfig = {};
+        },
     },
 });
 
@@ -104,6 +118,9 @@ export const getPmicConfigData = (state: RootState) =>
 
 export const getHardwareConfig = (state: RootState) =>
     state.app.boardControllerConfig.hardwareConfig;
+
+export const getDefaultConfig = (state: RootState) =>
+    state.app.boardControllerConfig.defaultConfig;
 
 export const getConfigArray = createSelector(
     [getConfigData, getPmicConfigData],
@@ -135,6 +152,8 @@ export const {
     clearPmicConfig,
     setHardwareConfig,
     clearHardwareConfig,
+    setDefaultConfig,
+    clearDefaultConfig,
 } = boardControllerConfigSlice.actions;
 
 export default boardControllerConfigSlice;

--- a/src/features/Configuration/boardDefinitions.ts
+++ b/src/features/Configuration/boardDefinitions.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { Device } from '@nordicsemiconductor/pc-nrfconnect-shared';
+
+import BoardControllerConfigDefinition from '../../common/boards/BoardControllerConfigDefinition';
+import nrf54h20json from '../../common/boards/nrf_PCA10145_54H20.json';
+import nrf9161v091json from '../../common/boards/nrf_PCA10153_0.9.1_9161.json';
+import nrf9161v0100json from '../../common/boards/nrf_PCA10153_0.10.0_9161.json';
+import nrf54l15v020json from '../../common/boards/nrf_PCA10156_0.2.0.json';
+import nrf54l15v030json from '../../common/boards/nrf_PCA10156_0.3.0.json';
+import nrf9151v020json from '../../common/boards/nrf_PCA10171_0.2.0_9151.json';
+
+export type BoardDefinition = {
+    boardControllerConfigDefinition?: BoardControllerConfigDefinition;
+    controlFlag?: {
+        unrecognizedBoard?: boolean;
+        unknownRevision?: boolean;
+        noRevision?: boolean;
+    };
+};
+
+const typednrf9161json = nrf9161v0100json as BoardControllerConfigDefinition;
+const typednrf9161v091 = nrf9161v091json as BoardControllerConfigDefinition;
+const typednrf54l15v020json =
+    nrf54l15v020json as BoardControllerConfigDefinition;
+const typednrf54l15v030json =
+    nrf54l15v030json as BoardControllerConfigDefinition;
+const typednrf54h20json = nrf54h20json as BoardControllerConfigDefinition;
+const typednrf9151v020json = nrf9151v020json as BoardControllerConfigDefinition;
+
+export function getBoardDefinition(
+    device: Device,
+    boardRevision: string | undefined
+): BoardDefinition {
+    switch (device?.devkit?.boardVersion) {
+        case 'PCA10156':
+            // nRF54L15
+            if (boardRevision === '0.3.0') {
+                return {
+                    boardControllerConfigDefinition: typednrf54l15v030json,
+                };
+            }
+
+            // Default is revision 0.2.0 or 0.2.1
+            return { boardControllerConfigDefinition: typednrf54l15v020json };
+
+        case 'PCA10153':
+            // nRF9161
+            if (boardRevision === '0.10.0') {
+                return { boardControllerConfigDefinition: typednrf9161json };
+            }
+            if (boardRevision === '0.9.0' || boardRevision === '0.9.1') {
+                return { boardControllerConfigDefinition: typednrf9161v091 };
+            }
+
+            if (!boardRevision) {
+                return { controlFlag: { noRevision: true } };
+            }
+
+            // return UnrecognizedBoardRevision();
+            return { controlFlag: { unknownRevision: true } };
+
+        case 'PCA10145':
+            // nRF54H20
+            return { boardControllerConfigDefinition: typednrf54h20json };
+
+        case 'PCA10171':
+            // nRF9151
+            return { boardControllerConfigDefinition: typednrf9151v020json };
+
+        default:
+            return { controlFlag: { unrecognizedBoard: true } };
+    }
+}


### PR DESCRIPTION
 * Refactor arbritation/selection of board configuration definitions. Prepare for dynamic loading of json-files.
 * Make default configuration part of config slice
 * Add a "Reset to board default"-button to the sidebar.

Doc notes: This PR adds a button to sidebar
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/assets/980843/1b4f3284-9424-4871-acbf-dd994782116f)
