### PR TITLE
NCD-764: Fix maximum voltage for nRF54L15-DKs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ EXPERIMENTAL RELEASE
 
 -   Names and descriptions to the PMIC ports
 
+### Changed
+
+-   Fix maximum voltage for nRF54L15-DKs
+
 ## 0.1.8 - UNRELEASED
 
 EXPERIMENTAL RELEASE

--- a/src/common/boards/nrf_PCA10156_0.2.0.json
+++ b/src/common/boards/nrf_PCA10156_0.2.0.json
@@ -46,7 +46,7 @@
             "portLabel": "VDD (nPM VOUT1)",
             "portDescription": "Voltage on the VDD rail",
             "mVmin": 1800,
-            "mVmax": 3000
+            "mVmax": 3300
         }
     ],
     "defaults": {

--- a/src/common/boards/nrf_PCA10156_0.3.0.json
+++ b/src/common/boards/nrf_PCA10156_0.3.0.json
@@ -55,7 +55,7 @@
             "portLabel": "VDD (nPM VOUT1)",
             "portDescription": "Voltage on the VDD rail",
             "mVmin": 1800,
-            "mVmax": 3000
+            "mVmax": 3300
         }
     ],
     "defaults": {


### PR DESCRIPTION
- Changed maximum voltage to 3.3V