### PR TITLE
Fix PCA10145/nRF54H20-PDK voltage selection pins

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ EXPERIMENTAL RELEASE
 ### Changed
 
 -   Fix maximum voltage for nRF54L15-DKs
+-   Fix voltage selections on nRF54H20-PDK
 
 ## 0.1.8 - UNRELEASED
 

--- a/src/common/boards/nrf_PCA10145_54H20.json
+++ b/src/common/boards/nrf_PCA10145_54H20.json
@@ -33,7 +33,8 @@
             "title": "GPIO port 1 Voltage",
             "label": "Voltage",
             "enable": {
-                "pin": 6
+                "pin": 6,
+                "invert": true
             },
             "alternatives": ["1V2", "1V8"]
         },
@@ -43,7 +44,8 @@
             "title": "GPIO port 2 Voltage",
             "label": "Voltage",
             "enable": {
-                "pin": 7
+                "pin": 7,
+                "invert": true
             },
             "alternatives": ["1V2", "1V8"]
         },
@@ -53,7 +55,8 @@
             "title": "GPIO port 7 Voltage",
             "label": "Voltage",
             "enable": {
-                "pin": 8
+                "pin": 8,
+                "invert": true
             },
             "alternatives": ["1V2", "1V8"]
         },


### PR DESCRIPTION
* Inverted some pins toggling between 1V2 and 1V8