### PR TITLE
Prepare for release of v0.1.9

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## NEXT - UNRELEASED
+## 0.1.9 - 2024-03-06
 
 EXPERIMENTAL RELEASE
 
@@ -12,7 +12,7 @@ EXPERIMENTAL RELEASE
 -   Fix maximum voltage for nRF54L15-DKs
 -   Fix voltage selections on nRF54H20-PDK
 
-## 0.1.8 - UNRELEASED
+## 0.1.8 - 2024-02-28
 
 EXPERIMENTAL RELEASE
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",


### PR DESCRIPTION
* Bumped version
* Updated Changelog

## 0.1.9 - 2024-03-06

### Added
-   Names and descriptions to the PMIC ports
-   Support for nRF54H20-DK r0.7.0

### Changed
-   Fix maximum voltage for nRF54L15-DKs
-   Fix voltage selections on nRF54H20-PDK