### PR TITLE
Prepare for release of v0.1.10

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+## 0.1.10 - 2024-03-06
+
+EXPERIMENTAL RELEASE
+
+### Changed
+
+-   Update dependency of pc-nrfconnect-shared to v166
+-   Lowered required nRF Connect for Desktop version to 4.4.0.
+
 ## 0.1.9 - 2024-03-06
 
 EXPERIMENTAL RELEASE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",


### PR DESCRIPTION
## 0.1.10 - 2024-03-06

EXPERIMENTAL RELEASE

### Changed

-   Update dependency of pc-nrfconnect-shared to v166
-   Lowered required nRF Connect for Desktop version to 4.4.0.
