### PR TITLE
NCD-768: Fix VCOM component UX

### DIFF
--- a/src/features/VCOMConfiguration/VCOMConfiguration.tsx
+++ b/src/features/VCOMConfiguration/VCOMConfiguration.tsx
@@ -63,9 +63,10 @@ const VCOMConfiguration = ({
                             </p>
                         }
                     >
-                        <span>Enable virtual COM port {vcomName} &#9432;</span>
+                        <span>Connect virtual COM port {vcomName} &#9432;</span>
                     </Overlay>
                     <Toggle
+                        label=""
                         isToggled={vcomEnable}
                         onToggle={enableVcom => {
                             dispatch(
@@ -103,6 +104,7 @@ const VCOMConfiguration = ({
                     </span>
                 </Overlay>
                 <Toggle
+                    disabled={!vcomEnable}
                     isToggled={hwfcEnable}
                     onToggle={enableHwfc => {
                         dispatch(

--- a/src/features/VCOMConfiguration/VCOMConfiguration.tsx
+++ b/src/features/VCOMConfiguration/VCOMConfiguration.tsx
@@ -51,22 +51,8 @@ const VCOMConfiguration = ({
     return (
         <Card
             title={
-                <div className="tw-flex tw-justify-between">
-                    <Overlay
-                        tooltipId={`tooltip_${vcomName}`}
-                        tooltipChildren={
-                            <p className="tooltip-text">
-                                Connect or disconnect the pins used for the
-                                virtual COM port. When disconnected, the
-                                corresponding UART GPIO pins can be used for
-                                other purposes.
-                            </p>
-                        }
-                    >
-                        <span>Connect virtual COM port {vcomName} &#9432;</span>
-                    </Overlay>
+                <div>
                     <Toggle
-                        label=""
                         isToggled={vcomEnable}
                         onToggle={enableVcom => {
                             dispatch(
@@ -78,34 +64,39 @@ const VCOMConfiguration = ({
                                     ),
                                 })
                             );
+                            // Also diconnect HWFC if VCOM is disconnected
+                            dispatch(
+                                setConfigValue({
+                                    configPin: hwfcEnablePin,
+                                    configPinState: xor(enableVcom, hwfcInvert),
+                                })
+                            );
                         }}
                     >
-                        Enable
+                        <Overlay
+                            tooltipId={`tooltip_${vcomName}`}
+                            tooltipChildren={
+                                <p className="tooltip-text">
+                                    Connect or disconnect the pins used for the
+                                    virtual COM port. When disconnected, the
+                                    corresponding UART GPIO pins can be used for
+                                    other purposes.
+                                </p>
+                            }
+                        >
+                            <span>
+                                Connect virtual COM port {vcomName}{' '}
+                                <span className="mdi mdi-help-circle-outline" />
+                            </span>
+                        </Overlay>
                     </Toggle>
                 </div>
             }
         >
-            <div className="tw-flex tw-justify-between">
-                <Overlay
-                    tooltipId={`tooltip_hwfc_${vcomName}`}
-                    tooltipChildren={
-                        <p className="tooltip-text">
-                            Connect or disconnect the Hardware Flow Control pins
-                            for the virtual COM port. When disconnected, the
-                            HWFC GPIO pins for the target chip can be used for
-                            other purposes. When connected, an autodetect
-                            feature is used to determine whether or not HWFC is
-                            enabled on the target chip.
-                        </p>
-                    }
-                >
-                    <span>
-                        Connect {vcomName} HWFC autodetect lines &#9432;
-                    </span>
-                </Overlay>
+            <div>
                 <Toggle
                     disabled={!vcomEnable}
-                    isToggled={hwfcEnable}
+                    isToggled={hwfcEnable && vcomEnable}
                     onToggle={enableHwfc => {
                         dispatch(
                             setConfigValue({
@@ -115,7 +106,25 @@ const VCOMConfiguration = ({
                         );
                     }}
                 >
-                    Enable
+                    <Overlay
+                        tooltipId={`tooltip_hwfc_${vcomName}`}
+                        tooltipChildren={
+                            <p className="tooltip-text">
+                                Connect or disconnect the Hardware Flow Control
+                                pins for the virtual COM port. When
+                                disconnected, the HWFC GPIO pins for the target
+                                chip can be used for other purposes. When
+                                connected, an autodetect feature is used to
+                                determine whether or not HWFC is enabled on the
+                                target chip.
+                            </p>
+                        }
+                    >
+                        <span>
+                            Connect {vcomName} HWFC autodetect lines
+                            <span className="mdi mdi-help-circle-outline" />
+                        </span>
+                    </Overlay>
                 </Toggle>
             </div>
         </Card>


### PR DESCRIPTION
 * Disable and disconnect HWFC when VCOM is disconnected
 * Remove enable-label
 * Use Material icon to indicate tooltip

UI Changes:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/assets/980843/9ae48798-9ae7-4364-a439-4a92137db912)

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/assets/980843/20d34874-17ec-4d71-bc6b-766ce0b712b4)

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/assets/980843/c4f51517-874a-4272-b0d3-5f4fcd1e191e)

Here the UI is shown with one disconnected and one connected VCOM. The HWFC toggle of the disconnected VCOM is also disconnected in addition to the toggle being disabled.
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/assets/980843/dec7abf3-1a05-4c55-be03-d170c3a85229)
