### PR TITLE
Prepare for release of v0.2.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,18 @@
+## 0.2.0 - 2024-03-22
+
+EXPERIMENTAL RELEASE
+
+### Added
+
+-   Support for nRF9161-DK r1.0.0, including PMIC configuration.
+
 ## 0.1.13 - 2024-03-21
 
 EXPERIMENTAL RELEASE
 
 ### Added
 
--   Support for nRF9161-DK r1.0.0
+-   Support for nRF9161-DK r1.0.0.
 
 ## 0.1.12 - 2024-03-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.1.13",
+    "version": "0.2.0",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",


### PR DESCRIPTION
## 0.2.0 - 2024-03-22

EXPERIMENTAL RELEASE

### Added

-   Support for nRF9161-DK r1.0.0, including PMIC configuration.
