### PR TITLE
NCD-770: Fix some missing classes

### DIFF
--- a/src/features/ConfigDataPreview/ConfigDataPreview.tsx
+++ b/src/features/ConfigDataPreview/ConfigDataPreview.tsx
@@ -158,17 +158,17 @@ interface PmicListProps {
 const PmicList = ({ pmicData }: PmicListProps) => {
     const ports = Array.from(pmicData.keys()).sort();
     return (
-        <div className="config-block tw-mb-6 tw-w-full">
+        <div className="tw-mb-6 tw-w-full">
             {ports.map(port => (
                 <div
-                    className="config-pin tw-h-10x -tw-mt-px tw-flex tw-w-full tw-items-center"
+                    className="tw-h-10x -tw-mt-px tw-flex tw-w-full tw-items-center"
                     key={`port-${port}`}
                 >
                     <div className="tw-mr-1x -tw-ml-px tw-flex tw-h-8 tw-w-8 tw-flex-none tw-items-center tw-border  tw-border-solid tw-border-gray-200 tw-p-1 tw-text-center tw-align-middle tw-text-gray-700">
-                        <div className="dip-label tw-m-auto">{port}</div>
+                        <div className="dip-label-text tw-m-auto">{port}</div>
                     </div>
                     <div className="tw-mr-1x -tw-ml-px tw-flex tw-h-8 tw-flex-1 tw-items-center tw-truncate tw-border  tw-border-solid tw-border-gray-200 tw-p-1">
-                        <div className="dip-label tw-w-full tw-flex-1 tw-truncate tw-pl-1">
+                        <div className="dip-label-text tw-w-full tw-flex-1 tw-truncate tw-pl-1">
                             {pmicData.get(port)} mV
                         </div>
                     </div>


### PR DESCRIPTION
Some CSS classes was changed for clarity, and the PMIC config table was forgotten. This patch fixes it, while also removing some unused class assignments.