### PR TITLE
doc: fix link to nRF Connect for Desktop docs

### DIFF
--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -3,7 +3,7 @@
 nRF Connect Board Configurator is an application that you can use to update the configuration of the board controller on Nordic Development kits.
 The board controller is the firmware running on the Interface MCU that controls the behavior of the DK.
 
-Board Configurator is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/ug_nrf_connect_desktop/page/struct/nrftools_nrfconnect.html) (v4.4.1 or later).
+Board Configurator is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html) (v4.4.1 or later).
 
 !!! note "Note"
       The current Board Configurator version is experimental. This means that the application is incomplete in functionality and will change in the future.


### PR DESCRIPTION
Fixed incorrect link.
Reported on Teams.