### PR TITLE
NCD-927: Add support for nRF54L15-PDF r0.7.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## 0.3.2 - UNRELEASED
+
+EXPERIMENTAL RELEASE
+
+### Added
+
+-   Support for nRF54L15-PDK r0.7.0.
+
 ## 0.3.1 - 2024-05-28
 
 EXPERIMENTAL RELEASE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",

--- a/src/features/Configuration/boardDefinitions.ts
+++ b/src/features/Configuration/boardDefinitions.ts
@@ -44,14 +44,18 @@ export function getBoardDefinition(
     switch (device?.devkit?.boardVersion) {
         case 'PCA10156':
             // nRF54L15
-            if (boardRevision === '0.3.0') {
+            if (
+                boardRevision === '0.1.0' || // Probably r0.2.0 with a firmware configuration error
+                boardRevision === '0.2.0' ||
+                boardRevision === '0.2.1'
+            ) {
                 return {
-                    boardControllerConfigDefinition: typednrf54l15v030json,
+                    boardControllerConfigDefinition: typednrf54l15v020json,
                 };
             }
 
-            // Default is revision 0.2.0 or 0.2.1
-            return { boardControllerConfigDefinition: typednrf54l15v020json };
+            // Default is revision 0.3.0 or higher
+            return { boardControllerConfigDefinition: typednrf54l15v030json };
 
         case 'PCA10153':
             // nRF9161


### PR DESCRIPTION
 * Make the board definition with SWD-toggle default for nRF54L15.
 * Use old definition on revisions prior to r0.3.0.