### PR TITLE
NCD-962: Indicate unwritten changes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## 0.3.4 - 2024-09-16
+
+EXPERIMENTAL RELEASE
+
+### Added
+
+-   Indicators showing unwritten changes
+
 ## 0.3.3 - 2024-08-01
 
 EXPERIMENTAL RELEASE

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ EXPERIMENTAL RELEASE
 
 ### Added
 
--   Indicators showing unwritten changes.
+-   Blue dot indicators for configuration options with unwritten changes.
 -   Icon and metadata for the nRF54L and nRF54H Series devices.
 
 ## 0.3.3 - 2024-08-01

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,8 @@ EXPERIMENTAL RELEASE
 
 ### Added
 
--   Indicators showing unwritten changes
+-   Indicators showing unwritten changes.
+-   Icon and metadata for nRF54 series.
 
 ## 0.3.3 - 2024-08-01
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ EXPERIMENTAL RELEASE
 ### Added
 
 -   Indicators showing unwritten changes.
--   Icon and metadata for nRF54 series.
+-   Icon and metadata for the nRF54L and nRF54H Series devices.
 
 ## 0.3.3 - 2024-08-01
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pc-nrfconnect-board-configurator",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^181.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^183.0.0",
                 "@types/react-test-renderer": "18.0.0"
             },
             "engines": {
-                "nrfconnect": ">=4.4.1"
+                "nrfconnect": ">=5.0.1"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -2848,9 +2848,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "181.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-181.0.0.tgz",
-            "integrity": "sha512-KSOViuWZEyG4caTMS/NUZuO8bKH5ubXta8k2ek8kcGNZjaZYaks2/H8R3vE3WDQsEU1XzKeFvJk+ok0BZR58Gw==",
+            "version": "183.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-183.0.0.tgz",
+            "integrity": "sha512-CjZeNWTSBCs+qa7WnXnQJVUB7Yim1y4tSI8Ysflj6K9JY9kNOaZmozAXMyYpJkBbUyO/MjhyjHcxUzN2AzBfKA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.3.4",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^183.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^184.0.0",
                 "@types/react-test-renderer": "18.0.0"
             },
             "engines": {
@@ -2848,9 +2848,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "183.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-183.0.0.tgz",
-            "integrity": "sha512-CjZeNWTSBCs+qa7WnXnQJVUB7Yim1y4tSI8Ysflj6K9JY9kNOaZmozAXMyYpJkBbUyO/MjhyjHcxUzN2AzBfKA==",
+            "version": "184.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-184.0.0.tgz",
+            "integrity": "sha512-v0/d/P/KRuWwsLvGsTnAE7vcsS3OTsyq1xKu+heHhNkf+EnyrND9nqDJfOxns9VtmKKRsLiSlo7m6fsWS5Qxig==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",
@@ -19,7 +19,7 @@
         ],
         "nrfutil": {
             "device": [
-                "2.4.3"
+                "2.5.0"
             ]
         },
         "html": "dist/index.html"
@@ -47,7 +47,7 @@
         "prepare": "husky install"
     },
     "devDependencies": {
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^181.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^183.0.0",
         "@types/react-test-renderer": "18.0.0"
     },
     "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "prepare": "husky install"
     },
     "devDependencies": {
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^183.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^184.0.0",
         "@types/react-test-renderer": "18.0.0"
     },
     "eslintConfig": {

--- a/src/SidePanel.tsx
+++ b/src/SidePanel.tsx
@@ -15,10 +15,12 @@ import {
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 import { NrfutilDeviceLib } from '@nordicsemiconductor/pc-nrfconnect-shared/nrfutil/device';
 
+import DirtyDot from './app/DirtyDot';
 import BoardInformation from './features/BoardInformation/BoardInformation';
 import ConfigDataPreview from './features/ConfigDataPreview/ConfigDataPreview';
 import ConfigJsonRender from './features/ConfigJsonRender/ConfigJsonRender';
 import {
+    getAnyConfigPinDirty,
     getConfigArray,
     getDefaultConfig,
     setConfig,
@@ -34,6 +36,7 @@ export default () => {
 
     const device = useSelector(selectedDevice);
     const configData = useSelector(getConfigArray);
+    const configDirty = useSelector(getAnyConfigPinDirty);
     const defaultConfig = useSelector(getDefaultConfig);
 
     return (
@@ -42,7 +45,7 @@ export default () => {
                 <button
                     type="button"
                     disabled={!device || isWriting}
-                    className="tw-preflight tw-h-8 tw-w-full  tw-border tw-border-gray-700 tw-bg-white tw-px-2 tw-text-xs tw-text-gray-700"
+                    className="tw-preflight tw-relative tw-h-8 tw-w-full  tw-border tw-border-gray-700 tw-bg-white tw-px-2 tw-text-xs tw-text-gray-700"
                     onClick={async () => {
                         // Set isWriting flag for user ui feedback
                         setWriting(true);
@@ -59,6 +62,10 @@ export default () => {
                     }}
                 >
                     Write config
+                    <DirtyDot
+                        className="tw-absolute tw-end-1.5 tw-top-1"
+                        dirty={configDirty}
+                    />
                 </button>
                 <Button
                     disabled={!device || isWriting || !defaultConfig}

--- a/src/app/DirtyDot.tsx
+++ b/src/app/DirtyDot.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+
+import './dirtydot.scss';
+
+interface DirtyDotProps {
+    dirty: boolean;
+    className?: string;
+}
+
+export default ({ dirty, className }: DirtyDotProps) =>
+    dirty ? (
+        <span
+            className={`mdi mdi-circle dirtydot tw-m-0 tw-p-0 tw-text-primary ${
+                className || ''
+            }`}
+        />
+    ) : null;

--- a/src/app/dirtydot.scss
+++ b/src/app/dirtydot.scss
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+.dirtydot {
+    font-size: 8px;
+}
+
+.dirtydot-tiny {
+    font-size: 4px;
+}

--- a/src/common/boards/BoardControllerConfigDefinition.ts
+++ b/src/common/boards/BoardControllerConfigDefinition.ts
@@ -43,6 +43,7 @@ type PmicPortDefinition = {
     mVmax: number;
     portLabel?: string;
     portDescription?: string;
+    portId?: string;
 };
 
 type BoardDefinition = {

--- a/src/features/ConfigDataPreview/ConfigDataPreview.tsx
+++ b/src/features/ConfigDataPreview/ConfigDataPreview.tsx
@@ -12,14 +12,18 @@ import {
     Group,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
+import DirtyDot from '../../app/DirtyDot';
 import {
     getConfigData,
+    getConfigDataDirty,
     getPmicConfigData,
+    getPmicConfigDataDirty,
     setConfigValue,
 } from '../Configuration/boardControllerConfigSlice';
 import {
     BoardDefinition,
     generatePinMap,
+    generatePortMap,
     getBoardDefinition,
 } from '../Configuration/boardDefinitions';
 import { getBoardRevisionSemver } from '../Device/deviceSlice';
@@ -32,7 +36,9 @@ interface ConfigDataPreviewProps {
 
 const ConfigDataPreview = ({ device }: ConfigDataPreviewProps) => {
     const configData = useSelector(getConfigData);
+    const configDataDirty = useSelector(getConfigDataDirty);
     const pmicData = useSelector(getPmicConfigData);
+    const pmicDataDirty = useSelector(getPmicConfigDataDirty);
     const boardRevision = useSelector(getBoardRevisionSemver);
     const boardDefinition = getBoardDefinition(device, boardRevision);
 
@@ -42,6 +48,7 @@ const ConfigDataPreview = ({ device }: ConfigDataPreviewProps) => {
                 <Group heading="Pin configuration">
                     <ConfigList
                         configData={configData}
+                        configDataDirty={configDataDirty}
                         boardDefinition={boardDefinition}
                     />
                     <p className="dip-label">/ = active low</p>
@@ -49,7 +56,11 @@ const ConfigDataPreview = ({ device }: ConfigDataPreviewProps) => {
             )}
             {pmicData && pmicData.size > 0 && (
                 <Group heading="PMIC configuration">
-                    <PmicList pmicData={pmicData} />
+                    <PmicList
+                        pmicData={pmicData}
+                        pmicDataDirty={pmicDataDirty}
+                        boardDefinition={boardDefinition}
+                    />
                 </Group>
             )}
         </>
@@ -58,10 +69,15 @@ const ConfigDataPreview = ({ device }: ConfigDataPreviewProps) => {
 
 interface ConfigListProps {
     configData: Map<number, boolean>;
+    configDataDirty: Map<number, boolean>;
     boardDefinition: BoardDefinition;
 }
 
-const ConfigList = ({ configData, boardDefinition }: ConfigListProps) => {
+const ConfigList = ({
+    configData,
+    configDataDirty,
+    boardDefinition,
+}: ConfigListProps) => {
     const pins = Array.from(configData.keys()).sort((a, b) => a - b);
     const pinMap = generatePinMap(
         boardDefinition.boardControllerConfigDefinition
@@ -75,15 +91,21 @@ const ConfigList = ({ configData, boardDefinition }: ConfigListProps) => {
                     inverted: false,
                 };
 
+                const dirty = configDataDirty.get(pin) === true;
+
                 return (
                     <div
                         className="tw-h-10x -tw-mt-px tw-flex tw-w-full tw-items-center"
                         key={`pin-${pin}`}
                     >
-                        <div className="tw-mr-1x -tw-ml-px tw-flex tw-h-8 tw-w-8 tw-flex-none tw-items-center tw-border  tw-border-solid tw-border-gray-200 tw-p-1 tw-text-center tw-align-middle tw-text-gray-700">
+                        <div className="tw-mr-1x tw-relative -tw-ml-px tw-flex tw-h-8 tw-w-8 tw-flex-none tw-items-center tw-border  tw-border-solid tw-border-gray-200 tw-p-1 tw-text-center tw-align-middle tw-text-gray-700">
                             <div className="dip-label-text tw-m-auto">
                                 {pin}
                             </div>
+                            <DirtyDot
+                                dirty={dirty}
+                                className="dirtydot-tiny tw-absolute tw-end-0.5 tw-top-0.5"
+                            />
                         </div>
                         <div className="tw-mr-1x -tw-ml-px tw-flex tw-h-8 tw-flex-1 tw-items-center tw-truncate tw-border  tw-border-solid tw-border-gray-200 tw-p-1">
                             <div className="dip-label-text tw-w-full tw-flex-1 tw-truncate tw-pl-1">
@@ -154,26 +176,49 @@ const DipSwitchButton = ({
 
 interface PmicListProps {
     pmicData: Map<number, number>;
+    pmicDataDirty: Map<number, boolean>;
+    boardDefinition: BoardDefinition;
 }
-const PmicList = ({ pmicData }: PmicListProps) => {
+const PmicList = ({
+    pmicData,
+    pmicDataDirty,
+    boardDefinition,
+}: PmicListProps) => {
     const ports = Array.from(pmicData.keys()).sort();
+    const portMap = generatePortMap(
+        boardDefinition.boardControllerConfigDefinition
+    );
     return (
         <div className="tw-mb-6 tw-w-full">
-            {ports.map(port => (
-                <div
-                    className="tw-h-10x -tw-mt-px tw-flex tw-w-full tw-items-center"
-                    key={`port-${port}`}
-                >
-                    <div className="tw-mr-1x -tw-ml-px tw-flex tw-h-8 tw-w-8 tw-flex-none tw-items-center tw-border  tw-border-solid tw-border-gray-200 tw-p-1 tw-text-center tw-align-middle tw-text-gray-700">
-                        <div className="dip-label-text tw-m-auto">{port}</div>
-                    </div>
-                    <div className="tw-mr-1x -tw-ml-px tw-flex tw-h-8 tw-flex-1 tw-items-center tw-truncate tw-border  tw-border-solid tw-border-gray-200 tw-p-1">
-                        <div className="dip-label-text tw-w-full tw-flex-1 tw-truncate tw-pl-1">
-                            {pmicData.get(port)} mV
+            {ports.map(port => {
+                const { id } = portMap.get(port) || { id: 'Unknown' };
+                return (
+                    <div
+                        className="tw-h-10x -tw-mt-px tw-flex tw-w-full tw-items-center"
+                        key={`port-${port}`}
+                    >
+                        <div className="tw-mr-1x tw-relative -tw-ml-px tw-flex tw-h-8 tw-w-8 tw-flex-none tw-items-center tw-border  tw-border-solid tw-border-gray-200 tw-p-1 tw-text-center tw-align-middle tw-text-gray-700">
+                            <div className="dip-label-text tw-m-auto">
+                                {port}
+                            </div>
+                            <DirtyDot
+                                dirty={pmicDataDirty.get(port) === true}
+                                className="dirtydot-tiny tw-absolute tw-end-0.5 tw-top-0.5"
+                            />
+                        </div>
+                        <div className="tw-mr-1x -tw-ml-px tw-flex tw-h-8 tw-flex-1 tw-items-center tw-truncate tw-border  tw-border-solid tw-border-gray-200 tw-p-1">
+                            <div className="dip-label-text tw-w-full tw-flex-1 tw-truncate tw-text-center">
+                                {id}
+                            </div>
+                        </div>
+                        <div className="tw-mr-1x -tw-ml-px tw-flex tw-h-8 tw-flex-1 tw-items-center tw-truncate tw-border  tw-border-solid tw-border-gray-200 tw-p-1">
+                            <div className="dip-label-text tw-w-full tw-flex-1 tw-truncate tw-text-center">
+                                {pmicData.get(port)} mV
+                            </div>
                         </div>
                     </div>
-                </div>
-            ))}
+                );
+            })}
         </div>
     );
 };

--- a/src/features/ConfigSlideSelector/ConfigSlideSelector.tsx
+++ b/src/features/ConfigSlideSelector/ConfigSlideSelector.tsx
@@ -12,7 +12,9 @@ import {
     StateSelector,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
+import DirtyDot from '../../app/DirtyDot';
 import {
+    getConfigPinDirty,
     getConfigValue,
     setConfigValue,
 } from '../Configuration/boardControllerConfigSlice';
@@ -39,11 +41,19 @@ const ConfigSlideSelector = ({
     const pinEnable = xor(useSelector(getConfigValue(configPin)), invert);
     const selectedItem = configAlternatives[pinEnable ? 1 : 0];
 
+    const dirty = useSelector(getConfigPinDirty(configPin));
+
     return (
         <Card
             title={
                 <div className="tw-flex tw-content-between">
-                    <span>{configTitle}</span>
+                    <span>
+                        {configTitle}
+                        <DirtyDot
+                            dirty={dirty}
+                            className="tw-absolute tw-ml-1 -tw-translate-y-2"
+                        />
+                    </span>
                 </div>
             }
         >

--- a/src/features/ConfigSwitch/ConfigSwitch.tsx
+++ b/src/features/ConfigSwitch/ConfigSwitch.tsx
@@ -12,7 +12,9 @@ import {
     Toggle,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
+import DirtyDot from '../../app/DirtyDot';
 import {
+    getConfigPinDirty,
     getConfigValue,
     setConfigValue,
 } from '../Configuration/boardControllerConfigSlice';
@@ -36,6 +38,8 @@ const ConfigSwitch = ({
 
     const toggleEnable = xor(useSelector(getConfigValue(configPin)), invert);
 
+    const dirty = useSelector(getConfigPinDirty(configPin));
+
     return (
         <Card
             title={
@@ -51,7 +55,13 @@ const ConfigSwitch = ({
                             )
                         }
                     >
-                        <span className="h5">{configTitle}</span>
+                        <span>
+                            <span className="h5">{configTitle}</span>
+                            <DirtyDot
+                                dirty={dirty}
+                                className="tw-absolute tw-ml-1 -tw-translate-x-1 -tw-translate-y-1/2"
+                            />
+                        </span>
                     </Toggle>
                 </div>
             }

--- a/src/features/Configuration/boardControllerConfigSlice.ts
+++ b/src/features/Configuration/boardControllerConfigSlice.ts
@@ -50,18 +50,14 @@ const boardControllerConfigSlice = createSlice({
         ) {
             state.boardControllerConfigData.set(configPin, configPinState);
 
-            const currentConfig = state.hardwareConfig.pins?.get(configPin);
-
-            // Set the pin dirty if..
+            // Update dirty flag
             state.boardControllerConfigDataDirty.set(
                 configPin,
-                // ..the current config is not what is stored on the board
-                (currentConfig !== undefined &&
-                    configPinState !== currentConfig) ||
-                    // .. or current config is not the default when no value is stored on the board
-                    (currentConfig === undefined &&
-                        configPinState !==
-                            state.defaultConfig.pins?.get(configPin))
+                computeDirtyFlag(
+                    configPinState,
+                    state.hardwareConfig.pins?.get(configPin),
+                    state.defaultConfig.pins?.get(configPin)
+                )
             );
         },
 
@@ -87,19 +83,14 @@ const boardControllerConfigSlice = createSlice({
         ) {
             state.pmicConfigData.set(pmicConfigPort, configPinState);
 
-            const currentConfig =
-                state.hardwareConfig.pmicPorts?.get(pmicConfigPort);
-
-            // Set the port dirty if..
+            // Update dirty flag
             state.pmicConfigDataDirty.set(
                 pmicConfigPort,
-                // ..the current config is not what is stored on the board
-                (currentConfig !== undefined &&
-                    configPinState !== currentConfig) ||
-                    // .. or current config is not the default when no value is stored on the board
-                    (currentConfig === undefined &&
-                        configPinState !==
-                            state.defaultConfig.pmicPorts?.get(pmicConfigPort))
+                computeDirtyFlag(
+                    configPinState,
+                    state.hardwareConfig.pmicPorts?.get(pmicConfigPort),
+                    state.defaultConfig.pmicPorts?.get(pmicConfigPort)
+                )
             );
         },
         clearPmicConfig(state) {
@@ -211,6 +202,21 @@ function avoidEmptyConfigArray(array: (number | boolean | undefined)[]) {
     }
 
     return array;
+}
+
+function computeDirtyFlag<T>(
+    configState: T,
+    currentHardwareConfig: T,
+    defaultConfig: T
+): boolean {
+    // The value is dirty if..
+    return (
+        // the current config is not what is stored on the board
+        (currentHardwareConfig !== undefined &&
+            configState !== currentHardwareConfig) ||
+        // .. or current config is not the default when no value is stored on the board
+        (currentHardwareConfig === undefined && configState !== defaultConfig)
+    );
 }
 
 export const {

--- a/src/features/Configuration/boardDefinitions.ts
+++ b/src/features/Configuration/boardDefinitions.ts
@@ -132,3 +132,21 @@ export function generatePinMap(
 
     return pinMap;
 }
+
+type PmicPortDescription = {
+    id: string;
+};
+
+export function generatePortMap(
+    boardControllerConfigDefinition: BoardControllerConfigDefinition | undefined
+): Map<number, PmicPortDescription> {
+    const pinMap = new Map<number, PmicPortDescription>();
+
+    boardControllerConfigDefinition?.pmicPorts?.forEach(port => {
+        if (port.portId) {
+            pinMap.set(port.port, { id: port.portId });
+        }
+    });
+
+    return pinMap;
+}

--- a/src/features/VCOMConfiguration/VCOMConfiguration.tsx
+++ b/src/features/VCOMConfiguration/VCOMConfiguration.tsx
@@ -13,7 +13,9 @@ import {
     Toggle,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
+import DirtyDot from '../../app/DirtyDot';
 import {
+    getConfigPinDirty,
     getConfigValue,
     setConfigValue,
 } from '../Configuration/boardControllerConfigSlice';
@@ -47,6 +49,9 @@ const VCOMConfiguration = ({
         useSelector(getConfigValue(hwfcEnablePin)),
         hwfcInvert
     );
+
+    const vcomEnableDirty = useSelector(getConfigPinDirty(vcomEnablePin));
+    const hwfcEnableDirty = useSelector(getConfigPinDirty(hwfcEnablePin));
 
     return (
         <Card
@@ -89,6 +94,10 @@ const VCOMConfiguration = ({
                             <span className="h5">
                                 Connect port {vcomName}{' '}
                                 <span className="mdi mdi-help-circle-outline" />
+                                <DirtyDot
+                                    dirty={vcomEnableDirty}
+                                    className="tw-absolute tw-ml-1 -tw-translate-y-2"
+                                />
                             </span>
                         </Overlay>
                     </Toggle>
@@ -127,6 +136,10 @@ const VCOMConfiguration = ({
                         <span>
                             {vcomName} HWFC autodetect lines
                             <span className="mdi mdi-help-circle-outline tw-pl-1" />
+                            <DirtyDot
+                                dirty={hwfcEnableDirty}
+                                className="tw-absolute tw-ml-1 -tw-translate-y-2"
+                            />
                         </span>
                     </Overlay>
                 </Toggle>

--- a/src/features/VoltageConfiguration/VoltageConfiguration.tsx
+++ b/src/features/VoltageConfiguration/VoltageConfiguration.tsx
@@ -12,8 +12,10 @@ import {
     NumberInput,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
+import DirtyDot from '../../app/DirtyDot';
 import {
     getPmicConfigValue,
+    getPmicConfigValueDirty,
     setPmicConfigValue,
 } from '../Configuration/boardControllerConfigSlice';
 
@@ -35,6 +37,8 @@ const VoltageConfiguration = ({
     const dispatch = useDispatch();
     const voltage = useSelector(getPmicConfigValue(pmicPort)) ?? voltageMin; // Default to voltageMin
 
+    const dirty = useSelector(getPmicConfigValueDirty(pmicPort));
+
     const label = pmicPortLabel ?? `Voltage port ${pmicPort}`;
     const description =
         pmicPortDescription ??
@@ -53,7 +57,13 @@ const VoltageConfiguration = ({
         <Card
             title={
                 <div className="tw-flex tw-content-between">
-                    <span>{label}</span>
+                    <span>
+                        {label}
+                        <DirtyDot
+                            dirty={dirty}
+                            className="tw-absolute tw-ml-1 -tw-translate-y-2"
+                        />
+                    </span>
                 </div>
             }
         >


### PR DESCRIPTION
This feature is keeping track of which config is read from the board on connection, and will indicate any deviation from that baseline. If no config is read (ie. the board is not configured) for a pin, the baseline will be the default for the pin.

Dependencies to shared and nrfutil are also updated.

![image](https://github.com/user-attachments/assets/22ea68e1-f3a4-451d-8682-c57c90e1ce8d)
