### PR TITLE
NCD-771: UX review of first version

### DIFF
--- a/src/features/VoltageConfiguration/VoltageConfiguration.tsx
+++ b/src/features/VoltageConfiguration/VoltageConfiguration.tsx
@@ -131,7 +131,7 @@ const PresetButton = ({ pmicPort, voltage, selected }: PresetButtonProps) => {
             className={classNames(
                 'tw-preflight tw-h-5 tw-w-full tw-border-gray-200 tw-px-2 tw-text-xs',
                 'tw-border tw-text-gray-700 active:enabled:tw-bg-gray-50',
-                selected ? 'tw-bg-gray-50' : 'tw-bg-white'
+                selected ? 'tw-bg-white' : 'tw-bg-gray-50'
             )}
             onClick={() => {
                 dispatch(


### PR DESCRIPTION
Only a single change from this UX review:
* Make the VoltageConfiguration preset buttons active white and inactive grey. (Instead of the opposite.)

![image](https://github.com/user-attachments/assets/33a7f95a-0e1a-48f2-9f52-0b5a1ec23b1c)

