### PR TITLE
Prepare for release v0.3.5

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## 0.3.5 - 2024-09-24
+
+EXPERIMENTAL RELEASE
+
+### Fixed
+
+-   Bug where indicator of unwritten changes was not cleared on config write.
+
 ## 0.3.4 - 2024-09-19
 
 EXPERIMENTAL RELEASE
@@ -9,7 +17,7 @@ EXPERIMENTAL RELEASE
 
 ### Changed
 
--   Updated shared components
+-   Updated shared components.
 
 ## 0.3.3 - 2024-08-01
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pc-nrfconnect-board-configurator",
-            "version": "0.3.4",
+            "version": "0.3.5",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
                 "@nordicsemiconductor/pc-nrfconnect-shared": "^184.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",


### PR DESCRIPTION
## 0.3.5 - 2024-09-24

EXPERIMENTAL RELEASE

### Fixed

-   Bug where indicator of unwritten changes was not cleared on config write.
