### PR TITLE
NCD-1044: Added nRF54 notes to main screen

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## 0.3.7 - 2024-09-30
+
+EXPERIMENTAL RELEASE
+
+### Fixed
+
+-   Added note about new supported kits.
+
 ## 0.3.6 - 2024-09-26
 
 EXPERIMENTAL RELEASE

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pc-nrfconnect-board-configurator",
-            "version": "0.3.6",
+            "version": "0.3.7",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
                 "@nordicsemiconductor/pc-nrfconnect-shared": "^184.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",

--- a/src/features/Configuration/Configuration.tsx
+++ b/src/features/Configuration/Configuration.tsx
@@ -97,7 +97,7 @@ const NoBoardSelected = () => (
                     target="_blank"
                     rel="noreferrer"
                 >
-                    nRF9161-DK (Rev. 0.9.0 and later)
+                    nRF9161 DK (Rev. 0.9.0 and later)
                 </a>
             </li>
             <li>
@@ -106,7 +106,7 @@ const NoBoardSelected = () => (
                     target="_blank"
                     rel="noreferrer"
                 >
-                    nRF9151-DK
+                    nRF9151 DK
                 </a>
             </li>
             <li>
@@ -115,7 +115,7 @@ const NoBoardSelected = () => (
                     target="_blank"
                     rel="noreferrer"
                 >
-                    nRF54L15-PDK
+                    nRF54L15 DK
                 </a>
             </li>
             <li>
@@ -124,7 +124,7 @@ const NoBoardSelected = () => (
                     target="_blank"
                     rel="noreferrer"
                 >
-                    nRF54H20-PDK
+                    nRF54H20 DK
                 </a>
             </li>
         </ul>

--- a/src/features/Configuration/Configuration.tsx
+++ b/src/features/Configuration/Configuration.tsx
@@ -124,7 +124,7 @@ const NoBoardSelected = () => (
                     target="_blank"
                     rel="noreferrer"
                 >
-                    nRF54H20 DK
+                    nRF54H20 PDK
                 </a>
             </li>
         </ul>

--- a/src/features/Configuration/Configuration.tsx
+++ b/src/features/Configuration/Configuration.tsx
@@ -109,6 +109,24 @@ const NoBoardSelected = () => (
                     nRF9151-DK
                 </a>
             </li>
+            <li>
+                <a
+                    href="https://www.nordicsemi.com/Products/nRF54L15"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    nRF54L15-PDK
+                </a>
+            </li>
+            <li>
+                <a
+                    href="https://www.nordicsemi.com/Products/nRF54H20"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    nRF54H20-PDK
+                </a>
+            </li>
         </ul>
     </div>
 );


### PR DESCRIPTION
Added notes for both nRF54L15 and nRF54H20.

![Screenshot_20240930_161507](https://github.com/user-attachments/assets/11c6e188-33eb-46a0-9e68-d6c6655b3f62)
