### PR TITLE
doc: remove nrf connect from app name in docs + edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
 The Board Configurator app in nRF Connect for Desktop lets you update the
-configuration of the board controller on some Development Kits from Nordic Semiconductor. The board
-controller is the firmware running on the Interface MCU that controls the
-behavior of the DK.
+configuration of the board controller on some Development Kits from Nordic
+Semiconductor. The board controller is the firmware running on the Interface MCU
+that controls the behavior of the DK.
 
-**Note:** Currently, the Board Configurator app is experimental. This means that the application is
-incomplete in functionality and will change in the future.
+**Note:** Currently, the Board Configurator app is experimental. This means that
+the application is incomplete in functionality and will change in the future.
 
 ![screenshot](resources/screenshot.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
-# nRF Connect Board Configurator
+# Board Configurator app
 
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-boilerplate?branchName=master)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=10&branchName=master)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-nRF Connect Board Configurator is an application that you can use to update the
-configuration of the board controller on Nordic Development kits. The board
+The Board Configurator app in nRF Connect for Desktop lets you update the
+configuration of the board controller on some Development Kits from Nordic Semiconductor. The board
 controller is the firmware running on the Interface MCU that controls the
 behavior of the DK.
 
-**Note:** The current Board Configurator version is experimental. This means
-that the application is incomplete in functionality and will change in the
-future.
+**Note:** Currently, the Board Configurator app is experimental. This means that the application is
+incomplete in functionality and will change in the future.
 
 ![screenshot](resources/screenshot.gif)
 
 ## Installation
 
-nRF Connect Board Configurator is installed from nRF Connect from Desktop. For
+The Board Configurator app is installed from nRF Connect from Desktop. For
 detailed steps, see
 [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
 in the nRF Connect from Desktop documentation.
@@ -24,7 +23,7 @@ in the nRF Connect from Desktop documentation.
 ## Documentation
 
 Read the
-[nRF Connect Board Configurator](https://docs.nordicsemi.com/bundle/nrf-connect-board-configurator/page/index.html)
+[Board Configurator app](https://docs.nordicsemi.com/bundle/nrf-connect-board-configurator/page/index.html)
 official documentation.
 
 ## Development

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,12 +1,12 @@
-# nRF Connect Board Configurator
+# {{app_name}}
 
-nRF Connect Board Configurator is an application that you can use to update the configuration of the board controller on Nordic Development kits.
+The {{app_name}} in nRF Connect for Desktop lets you update the configuration of the board controller on some Development Kits from Nordic Semiconductor.
 The board controller is the firmware running on the Interface MCU that controls the behavior of the DK.
 
-Board Configurator is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html) (v4.4.1 or later).
+The {{app_name}} is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html) (v4.4.1 or later).
 
 !!! note "Note"
-      The current Board Configurator version is experimental. This means that the application is incomplete in functionality and will change in the future.
+      Currently, the {{app_name}} is experimental. This means that the application is incomplete in functionality and will change in the future.
 
 ## Supported devices
 

--- a/doc/docs/installing.md
+++ b/doc/docs/installing.md
@@ -1,3 +1,3 @@
-# Installing Board Configurator app
+# Installing the Board Configurator app
 
 For installation instructions, see [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html) in the nRF Connect for Desktop documentation.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -1,8 +1,8 @@
 # Overview and user interface
 
-After starting Board Configurator, the main application window is displayed.
+After starting the {{app_name}}, the main application window is displayed.
 
-![Board Configurator application window](./screenshots/board_configurator_overview.png "Board Configurator application window")
+![{{app_name}} window](./screenshots/board_configurator_overview.png "{{app_name}} window")
 
 The available options and information change after you **Select Device**.
 
@@ -41,7 +41,7 @@ This side panel area lists advanced information about the board controller confi
 
 In the **Configuration** tab, you can see the options that you can [configure](updating.md) for the selected development kit.
 
-![Board Configurator configuration tab](./screenshots/board_configurator_connected.png "Board Configurator configuration tab")
+![{{app_name}} configuration tab](./screenshots/board_configurator_connected.png "{{app_name}} configuration tab")
 
 ## Log
 
@@ -54,7 +54,7 @@ The Log panel allows you to view the most important log events, tagged with a ti
 
 ## Feedback tab
 
-The Feedback tab lets you send feedback about nRF Connect Board Configurator application to the application development team.
+The Feedback tab lets you send feedback about the {{app_name}} to the application development team.
 
 ## About tab
 

--- a/doc/docs/troubleshooting.md
+++ b/doc/docs/troubleshooting.md
@@ -1,20 +1,20 @@
 # Troubleshooting
 
-These troubleshooting instructions can help you fix issues you might encounter when working with Board Configurator.
+These troubleshooting instructions can help you fix issues you might encounter when working with the {{app_name}}.
 
 Remember to check the [Log](./overview.md#log) panel whenever you encounter a problem.
 To view more detailed information, use the **Open log file** option to open the current log file in a text editor.
 
-The Board Configurator app shares several of the troubleshooting issues and suggested solutions with the [nRF Connect Bluetooth Low Energy](https://docs.nordicsemi.com/bundle/nrf-connect-ble/page/index.html) app. Refer to the [troubleshooting section in the nRF Connect Bluetooth Low Energy user guide](https://docs.nordicsemi.com/bundle/nrf-connect-ble/page/troubleshooting.html) for the list of issues.
+The {{app_name}} shares several of the troubleshooting issues and suggested solutions with the [Bluetooth® Low Energy app](https://docs.nordicsemi.com/bundle/nrf-connect-ble/page/index.html) app. Refer to the [troubleshooting section in the Bluetooth® Low Energy app user guide](https://docs.nordicsemi.com/bundle/nrf-connect-ble/page/troubleshooting.html) for the list of issues.
 
 ## Unable to configure a device
 
 Verify that you are trying to program a [supported device](./index.md#supported-devices).
 
-## Restarting the Board Configurator app
+## Restarting the {{app_name}}
 
-You can restart the Board Configurator app by pressing Ctrl+R in Windows and command+R in macOS. A restart might be required in the following situations:
+You can restart the {{app_name}} by pressing Ctrl+R in Windows and command+R in macOS. A restart might be required in the following situations:
 
-- A device is reset while it is connected to the Board Configurator app.</br>
+- A device is reset while it is connected to the {{app_name}}.</br>
   In this case, you may not see all COM ports in the drop-down list while selecting the device in the app.
 - Other errors occur.

--- a/doc/docs/updating.md
+++ b/doc/docs/updating.md
@@ -1,10 +1,10 @@
 # Updating the board configuration
 
-In Board Configurator, you can update the configuration of the board controller on a [supported Nordic Semiconductor Development Kit](index.md#supported-devices).
+In the {{app_name}}, you can update the configuration of the board controller on a [supported Nordic Semiconductor Development Kit](index.md#supported-devices).
 
 To update the configuration of a development kit, complete the following steps:
 
-1. Open nRF Connect for Desktop and open nRF Connect Board Configurator.
+1. Open nRF Connect for Desktop and open the {{app_name}}.
 1. Connect a development kit to the computer with a USB cable and turn it on.
 1. Click [**Select Device**](./overview.md#select-device) and select the device from the drop-down list.</br>
    The application reads the Interface MCU configuration on the board.

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: nRF Connect Board Configurator documentation
+site_name: Board Configurator app documentation
 site_url:
 use_directory_urls: false
 
@@ -56,10 +56,11 @@ plugins:
 
 extra:
   test: This is a test abbreviation snippet
+  app_name: Board Configurator app
 
 nav:
   - Home: index.md
-  - Installing Board Configurator app: installing.md
+  - Installing the Board Configurator app: installing.md
   - Overview and user interface: overview.md
   - Updating the board configuration: updating.md
   - Troubleshooting: troubleshooting.md

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -42,9 +42,6 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.tabbed
   - pymdownx.superfences
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
   - toc:
       permalink: true
       toc_depth: 4

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -30,7 +30,7 @@ extra_css:
   - stylesheets/style.css
 
 copyright:
-  Copyright &copy; 2023
+  Copyright &copy; 2023-2024
 
 markdown_extensions:
   - abbr

--- a/doc/zoomin/custom.properties
+++ b/doc/zoomin/custom.properties
@@ -1,3 +1,3 @@
 manual.name=nrf-connect-board-configurator
-booktitle=nRF Connect Board Configurator
-shortdesc=Documentation for the nRF Connect Board Configurator application.
+booktitle=Board Configurator
+shortdesc=Documentation for the Board Configurator application.

--- a/src/features/Configuration/Configuration.tsx
+++ b/src/features/Configuration/Configuration.tsx
@@ -147,7 +147,7 @@ const UnrecognizedBoardRevision = () => (
     <div>
         <p>
             This revision of the development kit is not supported. Update to the
-            latest version of nRF Connect Board Configurator
+            latest version of the Board Configurator app
         </p>
     </div>
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,10 +16,10 @@ import BoilerplateDeviceSelector from './app/DeviceSelector';
 import Configuration from './features/Configuration/Configuration';
 import SidePanel from './SidePanel';
 
-// nRF Connect Board Configurator
-// ==============================
+// Board Configurator
+// ==================
 //
-// The Board Configurator helps configuring the Board Controller on the
+// The Board Configurator app helps configuring the Board Controller on the
 // nRF5340 IMCU on newer nRF devkits. The Board Controller will toggle
 // features on the devkit, like switching between internal or external
 // antenna, or which SIM option to use.


### PR DESCRIPTION
* Updated the application name to remove `nRF Connect`.
See reasoning in NCD-1066.
* Updated app name in code in-line output and docs.
* Removed pymdownx.emoji plugins that we don't use.
* Updated copyright year.