### PR TITLE
doc: add info about External memory for nRF54H20

### DIFF
--- a/doc/docs/revision_history.md
+++ b/doc/docs/revision_history.md
@@ -2,6 +2,7 @@
 
 | Date       | Description   |
 |------------|---------------|
+| November 2024  | Added information about the need to enable **External memory** option for nRF54H20 on the [Updating the board configuration](updating.md) and [Troubleshooting](troubleshooting.md#unable-to-perform-dfu-or-work-with-samples-on-nrf54h20) pages.  |
 | September 2024 | Updated documentation for the experimental [v0.3.4](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md):</br></br>- Added information about the blue dot icon that indicates unwritten changes.</br>- Updated the supported devices list with the nRF54H20 DK and the nRF54L15 DK. |
 | 2024-04-11 | Updated documentation for the experimental [v0.3.0](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md): Updates to the [Overview](overview.md) page. |
 | 2024-03-22 | Updated documentation for the experimental [v0.2.0](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md): Removed revision number next to the nRF9161 DK on the list of supported devices, given the support for the revision v1.0.0. |

--- a/doc/docs/troubleshooting.md
+++ b/doc/docs/troubleshooting.md
@@ -19,6 +19,6 @@ You can restart the {{app_name}} by pressing Ctrl+R in Windows and command+R in 
   In this case, you may not see all COM ports in the drop-down list while selecting the device in the app.
 - Other errors occur.
 
-## Unable to perform DFU or work with samples on nRF54H20
+## Unable to perform DFU with external flash on nRF54H20
 
 Verify that you have enabled the **External memory** chip option in the [**Configuration**](overview.md#configuration-tab) tab.

--- a/doc/docs/troubleshooting.md
+++ b/doc/docs/troubleshooting.md
@@ -18,3 +18,7 @@ You can restart the {{app_name}} by pressing Ctrl+R in Windows and command+R in 
 - A device is reset while it is connected to the {{app_name}}.</br>
   In this case, you may not see all COM ports in the drop-down list while selecting the device in the app.
 - Other errors occur.
+
+## Unable to perform DFU or work with samples on nRF54H20
+
+Verify that you have enabled the **External memory** chip option in the [**Configuration**](overview.md#configuration-tab) tab.

--- a/doc/docs/updating.md
+++ b/doc/docs/updating.md
@@ -16,7 +16,7 @@ To update the configuration of a development kit, complete the following steps:
 
     !!! info "Note"
           - Some options are interdependable. For example, if the VCOM is disconnected, the Hardware Flow Control will automatically be disconnected too.
-          - If you are working with nRF54H20, make sure to enable the **External memory** chip option to avoid [issues with DFU or some samples](troubleshooting.md#unable-to-perform-dfu-or-work-with-samples-on-nrf54h20).
+          - If you are working with nRF54H20, make sure to enable the **External memory** chip option to avoid [issues with DFU](./troubleshooting.md#unable-to-perform-dfu-with-external-flash-on-nrf54h20).
           - Advanced users can also configure some of the settings by toggling pins in the [**Pin Configuration**](overview.md#board-controller-info) section.
 
     The unwritten changes are highlighted with the blue dot next to the modified configuration option, as in the following example.

--- a/doc/docs/updating.md
+++ b/doc/docs/updating.md
@@ -14,13 +14,14 @@ To update the configuration of a development kit, complete the following steps:
 
 1. Configure the settings in the [**Configuration**](./overview.md#configuration-tab) tab.
 
-    !!! note "Note"
+    !!! info "Note"
           - Some options are interdependable. For example, if the VCOM is disconnected, the Hardware Flow Control will automatically be disconnected too.
+          - If you are working with nRF54H20, make sure to enable the **External memory** chip option to avoid [issues with DFU or some samples](troubleshooting.md#unable-to-perform-dfu-or-work-with-samples-on-nrf54h20).
           - Advanced users can also configure some of the settings by toggling pins in the [**Pin Configuration**](overview.md#board-controller-info) section.
 
     The unwritten changes are highlighted with the blue dot next to the modified configuration option, as in the following example.
 
-     ![Example of the blue dot indicating unwritten changes](./screenshots/board_configurator_unwritten_options.png "Example of the blue dot indicating unwritten changes")
+      ![Example of the blue dot indicating unwritten changes](./screenshots/board_configurator_unwritten_options.png "Example of the blue dot indicating unwritten changes")
 
 1. Click [**Write config**](./overview.md#actions) to upload the config to the device.</br>
    The application overwrites the default board controller configuration with the updated settings.


### PR DESCRIPTION
Added a note and a troubleshooting entry about the need to enable External memory option for nRF54H20.
NCD-1096 and NCSDK-29858.