### PR TITLE
NCD-1101: Update nrfutil-device dependency to v2.7.6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+## 0.3.10 - UNRELEASED
+
+EXPERIMENTAL RELEASE
+
+### Changed
+
+-   Updated `nrfutil device` to v2.7.6. Resolving bug where disabling SWD on the
+    DK prevented Board Configurator from reconnecting.
+
 ## 0.3.9 - 2024-11-12
 
 EXPERIMENTAL RELEASE

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.3.9",
+    "version": "0.3.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pc-nrfconnect-board-configurator",
-            "version": "0.3.9",
+            "version": "0.3.10",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
                 "@nordicsemiconductor/pc-nrfconnect-shared": "^188.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-board-configurator",
-    "version": "0.3.9",
+    "version": "0.3.10",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",
@@ -19,7 +19,7 @@
         ],
         "nrfutil": {
             "device": [
-                "2.7.3"
+                "2.7.6"
             ]
         },
         "html": "dist/index.html"


### PR DESCRIPTION
 * Updating to the latest version of nrfutil-device fixes the problem with connection failure when SWDCONTROL is set true in the configuration.