### PR TITLE
Remove UIs for configuring voltage for GPIO Ports 1,2 and 7 for nRF54H20 DK (PCA10175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,33 +46,3 @@ for details.
 ## License
 
 See the [LICENSE](LICENSE) file for details.
-
-
-# Notes
-hwfc - hardware flow control
-
-HOW TO ADD NEW BOARDS??
-Adding new board - pay attention to the polarity of the pins 
-
-Reading: hardware schematics & device tree files
-Source: https://nordicsemi.atlassian.net/wiki/spaces/APPS/pages/67295432/nRF5340+Board+Controller+-+1.6+nRF5340+Pinout
-
-Board controller project lead - Bjorn Spokeli 
-
-BC App = docs for the end users
-
-getBoardDefinition() switch - should be more sophisticated 
-
------
-Plan:
-- to have board definition file selection automatic - have getBoardDefinition() file automatic, like to have list of board revisions in the file
-- update board configuarator FW, but use case is small; also we don't know what FW will be correct for the specific board & revision
-- 
-
-TODO: ask Ingar why not 1.x release
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -46,3 +46,33 @@ for details.
 ## License
 
 See the [LICENSE](LICENSE) file for details.
+
+
+# Notes
+hwfc - hardware flow control
+
+HOW TO ADD NEW BOARDS??
+Adding new board - pay attention to the polarity of the pins 
+
+Reading: hardware schematics & device tree files
+Source: https://nordicsemi.atlassian.net/wiki/spaces/APPS/pages/67295432/nRF5340+Board+Controller+-+1.6+nRF5340+Pinout
+
+Board controller project lead - Bjorn Spokeli 
+
+BC App = docs for the end users
+
+getBoardDefinition() switch - should be more sophisticated 
+
+-----
+Plan:
+- to have board definition file selection automatic - have getBoardDefinition() file automatic, like to have list of board revisions in the file
+- update board configuarator FW, but use case is small; also we don't know what FW will be correct for the specific board & revision
+- 
+
+TODO: ask Ingar why not 1.x release
+
+
+
+
+
+

--- a/src/common/boards/nrf_PCA10175_1.0.0_54H20.json
+++ b/src/common/boards/nrf_PCA10175_1.0.0_54H20.json
@@ -1,0 +1,111 @@
+{
+    "board": {
+        "boardVersion": "PCA10175",
+        "boardRevision": "0.7.0",
+        "boardName": "nRF54H20 DK v0.7.0"
+    },
+    "pins": [
+        {
+            "type": "vcom",
+            "id": "vcom0",
+            "name": "VCOM0",
+            "enable": {
+                "pin": 42
+            },
+            "hwfc": {
+                "pin": 20
+            }
+        },
+        {
+            "type": "vcom",
+            "id": "vcom1",
+            "name": "VCOM1",
+            "enable": {
+                "pin": 22
+            },
+            "hwfc": {
+                "pin": 23
+            }
+        },
+        {
+            "type": "switch",
+            "id": "swd3-control",
+            "title": "Software Debugger (SWD)",
+            "label": "Disable to use an external debugger on the target chip.",
+            "tooltip": "When enabled, the SWD is connected and the IMCU is acting as the debugger. When disabled, the SWD is disconnected and you can use an external debugger connected to the Debug In header.",
+            "enable": {
+                "pin": 6
+            }
+        },
+        {
+            "type": "switch",
+            "id": "led-pwr-ctrl",
+            "title": "LED Power",
+            "label": "Disable LEDs to use the GPIOs for other purposes.",
+            "tooltip": "The LEDs are enabled by providing 5 V to LED0-LED3.",
+            "enable": {
+                "pin": 45
+            }
+        },
+        {
+            "type": "switch",
+            "id": "ldos-flash-dis",
+            "title": "External Memory",
+            "label": "Enable power to the external flash memory.",
+            "tooltip": "Enable external flash by powering the rails VCCQ_1V8 and VCC_1V8.",
+            "enable": {
+                "pin": 47,
+                "invert": true
+            }
+        }
+    ],
+    "pmicPorts": [
+        {
+            "type": "voltage",
+            "port": 1,
+            "portId": "vdd-p9",
+            "portLabel": "VDD-p9 (nPM VOUT2)",
+            "portDescription": "Voltage on the VDD rail of nRF54H20 P9.",
+            "mVmin": 1800,
+            "mVmax": 3300
+        }
+    ],
+    "defaults": {
+        "pins": [
+            {
+                "pin": 42,
+                "state": true
+            },
+            {
+                "pin": 20,
+                "state": true
+            },
+            {
+                "pin": 22,
+                "state": true
+            },
+            {
+                "pin": 23,
+                "state": true
+            },
+            {
+                "pin": 6,
+                "state": true
+            },
+            {
+                "pin": 45,
+                "state": true
+            },
+            {
+                "pin": 47,
+                "state": true
+            }
+        ],
+        "pmicPorts": [
+            {
+                "port": 1,
+                "voltage": 1800
+            }
+        ]
+    }
+}

--- a/src/common/boards/nrf_PCA10175_1.0.0_54H20.json
+++ b/src/common/boards/nrf_PCA10175_1.0.0_54H20.json
@@ -62,7 +62,7 @@
     "pmicPorts": [
         {
             "type": "voltage",
-            "port": 1,
+            "port": 2,
             "portId": "vdd-p9",
             "portLabel": "VDD-p9 (nPM VOUT2)",
             "portDescription": "Voltage on the VDD rail of nRF54H20 P9.",
@@ -103,7 +103,7 @@
         ],
         "pmicPorts": [
             {
-                "port": 1,
+                "port": 2,
                 "voltage": 1800
             }
         ]

--- a/src/common/boards/nrf_PCA10175_1.0.0_54H20.json
+++ b/src/common/boards/nrf_PCA10175_1.0.0_54H20.json
@@ -1,8 +1,8 @@
 {
     "board": {
         "boardVersion": "PCA10175",
-        "boardRevision": "0.7.0",
-        "boardName": "nRF54H20 DK v0.7.0"
+        "boardRevision": "1.0.0",
+        "boardName": "nRF54H20 DK v1.0.0"
     },
     "pins": [
         {

--- a/src/features/Configuration/boardDefinitions.ts
+++ b/src/features/Configuration/boardDefinitions.ts
@@ -15,6 +15,7 @@ import nrf54l15v020json from '../../common/boards/nrf_PCA10156_0.2.0.json';
 import nrf54l15v030json from '../../common/boards/nrf_PCA10156_0.3.0.json';
 import nrf9151v020json from '../../common/boards/nrf_PCA10171_0.2.0_9151.json';
 import nrf54h20v070json from '../../common/boards/nrf_PCA10175_0.7.0_54H20.json';
+import nrf54h20v100json from '../../common/boards/nrf_PCA10175_1.0.0_54H20.json';
 
 export type BoardDefinition = {
     boardControllerConfigDefinition?: BoardControllerConfigDefinition;
@@ -35,6 +36,8 @@ const typednrf54l15v030json =
 const typednrf54h20json = nrf54h20pdk080json as BoardControllerConfigDefinition;
 const typednrf54h20v070json =
     nrf54h20v070json as BoardControllerConfigDefinition;
+const typednrf54h20v100json =
+    nrf54h20v100json as BoardControllerConfigDefinition;
 const typednrf9151v020json = nrf9151v020json as BoardControllerConfigDefinition;
 
 export function getBoardDefinition(
@@ -86,7 +89,13 @@ export function getBoardDefinition(
 
         case 'PCA10175':
             // nRF54H20
-            return { boardControllerConfigDefinition: typednrf54h20v070json };
+            if (boardRevision === '0.7.0') {
+                return {
+                    boardControllerConfigDefinition: typednrf54h20v070json,
+                };
+            }
+
+            return { boardControllerConfigDefinition: typednrf54h20v100json };
 
         default:
             return { controlFlag: { unrecognizedBoard: true } };


### PR DESCRIPTION
FOR THE CHANGELOG WHEN ADDED: 

Removed
nRF54H20: Configuration fields for voltage for GPIO Ports 1, 2, and 7.

(from Greg)