### PR TITLE
Bump nrfutil-core to 8.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
                 "2.12.3"
             ]
         },
-        "nrfutilCore": "8.0.0",
+        "nrfutilCore": "8.1.1",
         "html": "dist/index.html"
     },
     "main": "dist/bundle.js",


### PR DESCRIPTION
Bump nrfutil-core to 8.1.1. Because https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/issues/1189 showed that it is necessary for some users.