### PR TITLE
doc: add supported device nRF54LV10

### DIFF
--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -13,6 +13,7 @@ The {{app_name}} is installed and updated using [nRF Connect for Desktop](https:
 - nRF9161 DK
 - nRF9151 DK
 - nRF54H20 DK
+- nRF54LV10 DK
 - nRF54LM20 DK
 - nRF54L15 DK
 


### PR DESCRIPTION
Added nRF54LV10 to the list of supported devices in the documentation. NCD-1439.