### PR TITLE
Remove useless eslintConfig from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,5 @@
         "@nordicsemiconductor/pc-nrfconnect-shared": "^219.0.0",
         "@types/react-test-renderer": "18.0.0"
     },
-    "eslintConfig": {
-        "extends": "./node_modules/@nordicsemiconductor/pc-nrfconnect-shared/config/eslintrc"
-    },
     "prettier": "@nordicsemiconductor/pc-nrfconnect-shared/config/prettier.config.js"
 }


### PR DESCRIPTION
Because this project already has a .eslintrc file, the eslintConfig entry is useless.