### PR TITLE
chore: point workflows and package URLs to nordicsemi org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
     build:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/build-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/build-app.yml@main

--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
     create-doc-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
         with:
             bundle-name: nrf-connect-board-configurator

--- a/.github/workflows/docs-publish-dev.yml
+++ b/.github/workflows/docs-publish-dev.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
     publish-docs-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
         with:
             bundle-name: nrf-connect-board-configurator
             release-type: dev

--- a/.github/workflows/docs-publish-prod.yml
+++ b/.github/workflows/docs-publish-prod.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     publish-docs-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
         with:
             bundle-name: nrf-connect-board-configurator
             release-type: prod

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
     check_labels:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/labels.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/labels.yml@main
         secrets: inherit

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     release:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
         with:
             source: latest (internal)
         secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
     release:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
         with:
             source: ${{ inputs.source }}
             ref: ${{ inputs.ref }}

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ official documentation.
 
 ## Development
 
-See the
-[app development](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/)
+See the [app development](https://nordicsemi.github.io/pc-nrfconnect-docs/)
 pages for details on how to develop apps for the nRF Connect for Desktop
 framework.
 
@@ -40,7 +39,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 ## Contributing
 
 See the
-[infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+[infos on contributing](https://nordicsemi.github.io/pc-nrfconnect-docs/contributing)
 for details.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Board Configurator app
 
-[![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-boilerplate?branchName=master)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=10&branchName=master)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
 The Board Configurator app in nRF Connect for Desktop lets you update the

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -19,5 +19,5 @@ For installation instructions, see [Installing nRF Connect for Desktop apps](htt
 
 ## Application source code
 
-The code of the application is open source and [available on GitHub](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator).
+The code of the application is open source and [available on GitHub](https://github.com/nordicsemi/pc-nrfconnect-board-configurator).
 Feel free to fork the repository and clone it for secondary development or feature contributions.

--- a/doc/docs/revision_history.yml
+++ b/doc/docs/revision_history.yml
@@ -21,22 +21,22 @@ sections:
   - "Added information about the need to enable **External memory** option for nRF54H20 on the [Updating the board configuration](updating.md) and [Troubleshooting](troubleshooting.md#unable-to-perform-dfu-with-external-flash-on-nrf54h20) pages."
 - name: September 2024
   entries:
-  - "Updated documentation for the experimental [v0.3.4](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md):"
+  - "Updated documentation for the experimental [v0.3.4](https://github.com/nordicsemi/pc-nrfconnect-board-configurator/blob/main/Changelog.md):"
   - "Added information about the blue dot icon that indicates unwritten changes."
   - "Updated the supported devices list with the nRF54H20 DK and the nRF54L15 DK."
 - name: April 2024
   entries:
-  - "Updated documentation for the experimental [v0.3.0](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md): Updates to the [Overview](overview.md) page."
+  - "Updated documentation for the experimental [v0.3.0](https://github.com/nordicsemi/pc-nrfconnect-board-configurator/blob/main/Changelog.md): Updates to the [Overview](overview.md) page."
 - name: March 2024
   entries:
-  - "Updated documentation for the experimental [v0.2.0](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md): Removed revision number next to the nRF9161 DK on the list of supported devices, given the support for the revision v1.0.0."
-  - "Updated documentation for the experimental [v0.1.12](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
-  - "Updated documentation for the experimental [v0.1.9](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
-  - "Updated documentation for the experimental [v0.1.8](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
+  - "Updated documentation for the experimental [v0.2.0](https://github.com/nordicsemi/pc-nrfconnect-board-configurator/blob/main/Changelog.md): Removed revision number next to the nRF9161 DK on the list of supported devices, given the support for the revision v1.0.0."
+  - "Updated documentation for the experimental [v0.1.12](https://github.com/nordicsemi/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
+  - "Updated documentation for the experimental [v0.1.9](https://github.com/nordicsemi/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
+  - "Updated documentation for the experimental [v0.1.8](https://github.com/nordicsemi/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
 - name: February 2024
   entries:
-  - "Added the nRF9151 DK to the list of supported devices with the release of [v0.1.6](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
-  - "Updated documentation for the experimental [v0.1.4](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
+  - "Added the nRF9151 DK to the list of supported devices with the release of [v0.1.6](https://github.com/nordicsemi/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
+  - "Updated documentation for the experimental [v0.1.4](https://github.com/nordicsemi/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
 - name: January 2024
   entries:
-  - "First release, for the experimental [v0.1.0](https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."
+  - "First release, for the experimental [v0.1.0](https://github.com/nordicsemi/pc-nrfconnect-board-configurator/blob/main/Changelog.md)."

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
     "version": "1.1.5",
     "description": "Configuration tool for Nordic Development Kits",
     "displayName": "Board Configurator",
-    "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator",
+    "homepage": "https://github.com/nordicsemi/pc-nrfconnect-board-configurator",
     "repository": {
         "type": "git",
-        "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-board-configurator"
+        "url": "https://github.com/nordicsemi/pc-nrfconnect-board-configurator"
     },
     "author": "Nordic Semiconductor ASA",
     "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Update reusable workflow references and repository homepage/URL from NordicSemiconductor to nordicsemi.

## Summary

Updates all reusable workflow `uses:` paths from `NordicSemiconductor/pc-nrfconnect-shared` to `nordicsemi/pc-nrfconnect-shared` to match the enterprise organization naming.

`package.json` `homepage` and `repository.url` point at the canonical **nordicsemi** org (not the former NordicSemiconductor naming).

## Notes

No functional workflow logic changes; only the repository path in composite/reusable workflow references, plus `package.json` metadata for the official GitHub location.